### PR TITLE
[bug] else block for X_original when self.auto_scaler is false

### DIFF
--- a/pysurvival/models/semi_parametric.py
+++ b/pysurvival/models/semi_parametric.py
@@ -602,6 +602,8 @@ class NonLinearCoxPHModel(BaseModel):
         # Scaling data 
         if self.auto_scaler:
             X_original = self.scaler.fit_transform( X ) 
+        else:
+            X_original = X
             
         # Sorting X, T, E in descending order according to T
         order = np.argsort(-T)


### PR DESCRIPTION
For the `NonLinearCoxPHModel` class, when `self.auto_scaler` is set to `False`, the code raises an `UnboundLocalError` exception like the following:

```
  File ".../pysurvival/models/semi_parametric.py", line 610, in fit
    X_original = X_original[order, :]
UnboundLocalError: local variable 'X_original' referenced before assignment
```

This pull request is a simple fix that avoids the exception with an else block, assigning `X_original` to the non-transformed input `X`.

Without this bug fix, `self.auto_scaler` must always be `True`, which forces the user into applying a the default sklearn `StandardScaler` to the input. But this may not always be a desirable transformation, for example, with binary or categorical/ordinal features.

Hope this is a welcome bug fix! Thanks.
