### PR TITLE
various changes to quiet build warnings

### DIFF
--- a/pysurvival/cpp_extensions/functions.cpp
+++ b/pysurvival/cpp_extensions/functions.cpp
@@ -29,19 +29,19 @@ vector<int>  argsort(vector<double> v, bool descending){
     vector<double> temp_v;
 
     if(descending){
-    	for (int i = 0; i < n; ++i){
+    	for (size_t i = 0; i < n; ++i){
     		temp_v.push_back(-v[i]);
     	}
     	v = temp_v;
     }
 
-    for (int i = 0; i < n; ++i){
+    for (size_t i = 0; i < n; ++i){
     	a.push_back(make_pair(v[i], i));
     }
 
     //sort indexes based on comparing values in v
     sort(a.begin(),a.end());
-    for (int i = 0; i < n; ++i){
+    for (size_t i = 0; i < n; ++i){
     	idx.push_back( a[i].second );
     }
     return idx;
@@ -53,7 +53,7 @@ vector<pair<double, double> > get_time_buckets(vector<double> times ){
     vector<pair<double, double> > results;
 
     // Computing the time buckets
-    for (int i = 0; i < N-1; ++i){
+    for (size_t i = 0; i < N-1; ++i){
         results.push_back(make_pair(times[i], times[i+1]));
     }
 
@@ -103,7 +103,7 @@ vector<double> reverse(vector<double> x){
 int argmin_buckets(double x, vector<pair<double, double> > buckets){
 	size_t index_x = 0, J = buckets.size();
 	double a, min_value = numeric_limits<double>::max();
-	for (int j = 0; j < J; ++j){
+	for (size_t j = 0; j < J; ++j){
 		a = buckets[j].first;
 		if(fabs(x-a)<= min_value){
 			min_value = fabs(x-a);
@@ -151,7 +151,7 @@ vector<double> cumsum( vector<double> v){
 	size_t N = v.size();
 	vector<double> results;
 	results.resize(N, 0.);
-	for (int i = 0; i < N; ++i){
+	for (size_t i = 0; i < N; ++i){
 		s += v[i];
 		results[i] = s;
 	}
@@ -186,7 +186,7 @@ map< int, vector<double> > baseline_functions(vector<double> score,
     vector<double> times, T_temp, E_temp;
     vector<int> desc_index = argsort(T, true);
     int n;
-    for (int i = 0; i < N; ++i){
+    for (size_t i = 0; i < N; ++i){
         n = desc_index[i];
         T_temp.push_back(T[n]);
         E_temp.push_back(E[n]);
@@ -195,7 +195,7 @@ map< int, vector<double> > baseline_functions(vector<double> score,
     E = E_temp;
 
 	// Calculating the Baseline hazard function
-    for (int i = 0; i < N; ++i){
+    for (size_t i = 0; i < N; ++i){
 
 		// Calculating the at risk variables
 		sum_theta_risk += score[i];

--- a/pysurvival/cpp_extensions/functions.cpp
+++ b/pysurvival/cpp_extensions/functions.cpp
@@ -205,7 +205,7 @@ map< int, vector<double> > baseline_functions(vector<double> score,
 			nb_fails += 1;
 		}
 
-		if (i < N-1 & T[i] == T[i+1]){
+		if (i < N-1 && T[i] == T[i+1]){
 			continue;
 		}
 

--- a/pysurvival/cpp_extensions/metrics.cpp
+++ b/pysurvival/cpp_extensions/metrics.cpp
@@ -69,7 +69,7 @@ map<int, double> concordance_index(vector<double> risk, vector<double> T,
 					w *= censored_km.predict_survival(T[i], true);
 
 					// count pairs 
-					if( (T[i]<T[j]) | (T[j]==T[i] & E[j]==0) ){
+					if( (T[i]<T[j]) || (T[j]==T[i] && E[j]==0) ){
 						weightedPairs += 1./w;
 
 						// concordant pairs
@@ -78,7 +78,7 @@ map<int, double> concordance_index(vector<double> risk, vector<double> T,
 						}
 
 						// pairs with equal predictions count 1/2 or nothing
-						if ((risk[i] == risk[j]) & include_ties){
+						if ((risk[i] == risk[j]) && include_ties){
 							weightedConcPairs += (1./w)/2.;
 						}
 

--- a/pysurvival/cpp_extensions/metrics.cpp
+++ b/pysurvival/cpp_extensions/metrics.cpp
@@ -141,7 +141,6 @@ map<int, vector<double> > brier_score(vector<vector<double> > Survival,
 
 	// Initializing/computing the brier score vector
 	M = times.size();
-	size_t Nt = time_buckets.size();
 	for (j = 0; j < M; ++j){
 		bs = 0.;
 

--- a/pysurvival/cpp_extensions/metrics.cpp
+++ b/pysurvival/cpp_extensions/metrics.cpp
@@ -129,7 +129,7 @@ map<int, vector<double> > brier_score(vector<vector<double> > Survival,
 	size_t i, j, M, N = Survival.size();
 	double censored_s, bs, t, S;
 	map<int, vector<double> > results;
-	int n, times_ = 0; //'times'
+	size_t n, times_ = 0; //'times'
 	int brier_scores_ = 1; //'brier_scores'
 	KaplanMeierModel censored_km;
 	vector<double> weights_km, times_to_consider, brier_scores_values;

--- a/pysurvival/cpp_extensions/non_parametric.cpp
+++ b/pysurvival/cpp_extensions/non_parametric.cpp
@@ -122,7 +122,7 @@ vector<double> KaplanMeierModel::fit(vector<double> T, vector<double> E,
     vector<double> T_temp, E_temp, weights_temp;
     vector<int> desc_index = argsort(T, true);
     int n;
-    for (int i = 0; i < N; ++i){
+    for (size_t i = 0; i < N; ++i){
         n = desc_index[i];
         T_temp.push_back(T[n]);
 
@@ -139,7 +139,7 @@ vector<double> KaplanMeierModel::fit(vector<double> T, vector<double> E,
 
     // Looping through the data to calculate Survival, hazard, 
     // Cumulative_Hazard and Variance 
-    for (int i = 0; i < N; ++i){
+    for (size_t i = 0; i < N; ++i){
 
         // Computing the at risk vector
         nb_at_risk += weights[i];
@@ -180,7 +180,7 @@ vector<double> KaplanMeierModel::fit(vector<double> T, vector<double> E,
     cum_std_error = 0.;
     survival_old = 1.;
 
-    for (int j = 0; j < Nt; ++j){
+    for (size_t j = 0; j < Nt; ++j){
 
         // Calculating hazard
         hazard_new = events[j]*1./at_risk[j];
@@ -382,7 +382,7 @@ vector<double> KernelModel::fit(vector<double> T, vector<double> E,
     	this->survival.push_back(1.-s);
     }
 
-    for (int i = 0; i < N; ++i){
+    for (size_t i = 0; i < N; ++i){
     	this->hazard.push_back( this->density[i]/max(this->survival[i], min_survival) );
     	this->cumulative_hazard.push_back(log(max(this->survival[i], min_survival)));
     }

--- a/pysurvival/cpp_extensions/non_parametric.cpp
+++ b/pysurvival/cpp_extensions/non_parametric.cpp
@@ -149,7 +149,7 @@ vector<double> KaplanMeierModel::fit(vector<double> T, vector<double> E,
             nb_events += weights[i];
         }
 
-        if (i < N-1 & T[i] == T[i+1]){
+        if (i < N-1 && T[i] == T[i+1]){
             continue;
         } else{
             times.push_back(T[i]);
@@ -315,7 +315,7 @@ vector<double> KernelModel::fit(vector<double> T, vector<double> E,
 
     // check if the kernel matrix fits in memory
     size = this->times.size()*km_times.size();
-    while(k_ < 10 & size/exp(k_*log(10)) > 1.){
+    while(k_ < 10 && size/exp(k_*log(10)) > 1.){
     	k_+=1;
     }
 

--- a/pysurvival/cpp_extensions/survival_forest.cpp
+++ b/pysurvival/cpp_extensions/survival_forest.cpp
@@ -1046,8 +1046,8 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
       }
 
       // Adjusting the number of threads to be <= number of cores
-      uint max_num_threads = (uint) thread::hardware_concurrency();
-      if ((num_threads < 0) | (num_threads >= max_num_threads)){
+      uint max_num_threads = thread::hardware_concurrency();
+      if ((num_threads < 0) | ((uint)num_threads >= max_num_threads)){
         num_threads = max_num_threads; 
       } else if(num_threads == 0){
             num_threads = 1; 
@@ -1157,8 +1157,8 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
     }
 
     // Adjusting the number of threads to be <= number of cores
-    uint max_num_threads = (uint) thread::hardware_concurrency();
-    if ((num_threads < 0) | (num_threads >= max_num_threads)){
+    uint max_num_threads = thread::hardware_concurrency();
+    if ((num_threads < 0) | ((uint)num_threads >= max_num_threads)){
       num_threads = max_num_threads; 
     } else if(num_threads == 0){
           num_threads = 1; 
@@ -1216,7 +1216,7 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
      std::string dependent_variable_name = this->variable_names[this->dependent_varID];
      std::string status_variable_name = this->variable_names[this->status_varID];
      std::vector<double> case_weights;
-     for (int i = 0; i < input_data.size(); ++i){
+     for (size_t i = 0; i < input_data.size(); ++i){
       case_weights.push_back(0.);
      }
      
@@ -1272,7 +1272,7 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
      std::string dependent_variable_name = this->variable_names[this->dependent_varID];
      std::string status_variable_name = this->variable_names[this->status_varID];
      std::vector<double> case_weights;
-     for (int i = 0; i < input_data.size(); ++i){
+     for (size_t i = 0; i < input_data.size(); ++i){
       case_weights.push_back(1./input_data.size());
      }
      
@@ -1327,7 +1327,7 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
      std::string dependent_variable_name = this->variable_names[this->dependent_varID];
      std::string status_variable_name = this->variable_names[this->status_varID];
      std::vector<double> case_weights;
-     for (int i = 0; i < input_data.size(); ++i){
+     for (size_t i = 0; i < input_data.size(); ++i){
       case_weights.push_back(1./input_data.size());
      }
      

--- a/pysurvival/cpp_extensions/survival_forest.cpp
+++ b/pysurvival/cpp_extensions/survival_forest.cpp
@@ -1006,7 +1006,6 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
       // variable names to be always selected
       std::vector<std::string> always_split_variable_names;
-      bool use_always_split_variable_names;
       always_split_variable_names.clear();
 
       // Dealing with unordered factor covariates-> all features are numerical so it doesn't apply
@@ -1062,8 +1061,6 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
       // Data
       std::unique_ptr<Data> data { };
-      size_t num_rows = input_data.size();
-      size_t num_cols = input_data[0].size();
       data = make_unique<Data>();
       data->loadData(input_data, variable_names);
 
@@ -1116,7 +1113,6 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
     // variable names to be always selected
     std::vector<std::string> always_split_variable_names;
-    bool use_always_split_variable_names;
     always_split_variable_names.clear();
 
     // Dealing with unordered factor covariates-> all features are numerical so it doesn't apply
@@ -1173,8 +1169,6 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
     // Data
     std::unique_ptr<Data> data { };
-    size_t num_rows = input_data.size();
-    size_t num_cols = input_data[0].size();
     data = make_unique<Data>();
     data->loadData(input_data, variable_names);
 

--- a/pysurvival/cpp_extensions/survival_forest.cpp
+++ b/pysurvival/cpp_extensions/survival_forest.cpp
@@ -1046,7 +1046,7 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
       // Adjusting the number of threads to be <= number of cores
       uint max_num_threads = thread::hardware_concurrency();
-      if ((num_threads < 0) | ((uint)num_threads >= max_num_threads)){
+      if ((num_threads < 0) || ((uint)num_threads >= max_num_threads)){
         num_threads = max_num_threads; 
       } else if(num_threads == 0){
             num_threads = 1; 
@@ -1154,7 +1154,7 @@ size_t ForestSurvival::getTreePredictionTerminalNodeID(size_t tree_idx, size_t s
 
     // Adjusting the number of threads to be <= number of cores
     uint max_num_threads = thread::hardware_concurrency();
-    if ((num_threads < 0) | ((uint)num_threads >= max_num_threads)){
+    if ((num_threads < 0) || ((uint)num_threads >= max_num_threads)){
       num_threads = max_num_threads; 
     } else if(num_threads == 0){
           num_threads = 1; 

--- a/pysurvival/cpp_extensions/survival_forest_data.h
+++ b/pysurvival/cpp_extensions/survival_forest_data.h
@@ -40,6 +40,7 @@ namespace ranger {
 			if (col < num_cols_no_snp) {
 				return data[col * num_rows + row];
 			}
+			throw std::runtime_error("get(): col out of bounds");
 		};
 
 		size_t getVariableID(const std::string& variable_name) const;
@@ -67,6 +68,7 @@ namespace ranger {
 			if (col < num_cols_no_snp) {
 				return index_data[col * num_rows + row];
 			}
+			throw std::runtime_error("getIndex(): col out of bounds");
 		}
 
 		void loadData(std::vector <std::vector<double> > Input_Data, std::vector<std::string> variable_names){


### PR DESCRIPTION
This PR quiets some build warnings from g++.

It includes a couple commits that are unlikely to affect correctness:

- quiet signedness comparison build warnings - adjust some `int` / `size_t`
  typing to avoid comparisons of different signedness

- remove some unused variables


It also includes a couple changes that will likely improve correctness (it
would be good to get additional review of these):

- fix some logical vs bitwise operator cases - fix tests in some `if` and
  `while` statements that were using bitwise operators (`&`, `|`) where
  probably the logical operators (`&&`, `||`) were intended

- avoid undefined behavior in SurvivalForest Data get() and getIndex() - these
  could reach end of function without an explicit return, resulting in
  undefined behavior. Appropriate return value not clear in those cases, so
  raise an exception.


A couple remaining build warnings are not addressed by this PR:

- a few more `int` vs `size_t` signedness comparison complaints from
  cython-generated code. These would require only minor changes to
  `_coxpy.pyx` and `_svm.pyx`, and regeneration of the `cpp` files with
  cython. Regenerating with current cython generates very large diffs
  so those changes are not included here.

- complaints about use of deprecated numpy APIs when building the
  cython-generated sources. Didn't investigate whether this would require
  any `pyx` code changes or just regeneration with current cython.