### PR TITLE
Remove vestigial sklearn.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ progressbar
 pyarrow
 scikit-learn 
 scipy
-sklearn
 torch


### PR DESCRIPTION
According to https://pypi.org/project/sklearn/, you're supposed to use
`scikit-learn` instead of `sklearn`. I don't think there's any problem
if you specify both of them, but it doesn't seem useful to have them
both here, and it's pretty confusing to see version 0.0 of some package
show up in our dependency graph.