### PR TITLE
Create .gitattributes & remove docs from github language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+docs linguist-vendored
+docs/* linguist-vendored
+*.html linguist-vendored
+*.css linguist-vendored
+*.js linguist-vendored


### PR DESCRIPTION
Mark `docs` contents (html, js, css) as vendored, to remove noise from github language stats