### PR TITLE
Make compatible with Python 3.10, lint and format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+install:
+	pip install -e ".[dev]"
+
+lint:
+	pylint --disable=all --enable=unused-import pysurvival
+
+fmt:
+	isort -rc .
+	black . --line-length 99
+
+test:
+	pytest .

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,24 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+matplotlib = "==3.8.0"
+numpy = "==1.26.0"
+pandas = "==2.1.1"
+progressbar = "==2.5"
+pyarrow = "==11.0.0"
+scikit-learn = "==1.3.1"
+scipy = "==1.11.3"
+torch = "==2.0.1"
+cython = "==3.0.2"
+
+[dev-packages]
+black = "*"
+isort = "*"
+pylint = "*"
+
+[requires]
+python_version = "3.10"
+python_full_version = "3.10.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,909 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "31ceb5fcb6101c5a0c80bbb0f6e05f3b008a8e4eda01534c9acdb76d0a71fb41"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_full_version": "3.10.11",
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "contourpy": {
+            "hashes": [
+                "sha256:059c3d2a94b930f4dafe8105bcdc1b21de99b30b51b5bce74c753686de858cb6",
+                "sha256:0683e1ae20dc038075d92e0e0148f09ffcefab120e57f6b4c9c0f477ec171f33",
+                "sha256:07d6f11dfaf80a84c97f1a5ba50d129d9303c5b4206f776e94037332e298dda8",
+                "sha256:081f3c0880712e40effc5f4c3b08feca6d064cb8cfbb372ca548105b86fd6c3d",
+                "sha256:0e48694d6a9c5a26ee85b10130c77a011a4fedf50a7279fa0bdaf44bafb4299d",
+                "sha256:11b836b7dbfb74e049c302bbf74b4b8f6cb9d0b6ca1bf86cfa8ba144aedadd9c",
+                "sha256:19557fa407e70f20bfaba7d55b4d97b14f9480856c4fb65812e8a05fe1c6f9bf",
+                "sha256:229a25f68046c5cf8067d6d6351c8b99e40da11b04d8416bf8d2b1d75922521e",
+                "sha256:24216552104ae8f3b34120ef84825400b16eb6133af2e27a190fdc13529f023e",
+                "sha256:3b53d5769aa1f2d4ea407c65f2d1d08002952fac1d9e9d307aa2e1023554a163",
+                "sha256:3de23ca4f381c3770dee6d10ead6fff524d540c0f662e763ad1530bde5112532",
+                "sha256:407d864db716a067cc696d61fa1ef6637fedf03606e8417fe2aeed20a061e6b2",
+                "sha256:41339b24471c58dc1499e56783fedc1afa4bb018bcd035cfb0ee2ad2a7501ef8",
+                "sha256:462c59914dc6d81e0b11f37e560b8a7c2dbab6aca4f38be31519d442d6cde1a1",
+                "sha256:46e24f5412c948d81736509377e255f6040e94216bf1a9b5ea1eaa9d29f6ec1b",
+                "sha256:498e53573e8b94b1caeb9e62d7c2d053c263ebb6aa259c81050766beb50ff8d9",
+                "sha256:4ebf42695f75ee1a952f98ce9775c873e4971732a87334b099dde90b6af6a916",
+                "sha256:4f9147051cb8fdb29a51dc2482d792b3b23e50f8f57e3720ca2e3d438b7adf23",
+                "sha256:549174b0713d49871c6dee90a4b499d3f12f5e5f69641cd23c50a4542e2ca1eb",
+                "sha256:560f1d68a33e89c62da5da4077ba98137a5e4d3a271b29f2f195d0fba2adcb6a",
+                "sha256:566f0e41df06dfef2431defcfaa155f0acfa1ca4acbf8fd80895b1e7e2ada40e",
+                "sha256:56de98a2fb23025882a18b60c7f0ea2d2d70bbbcfcf878f9067234b1c4818442",
+                "sha256:66544f853bfa85c0d07a68f6c648b2ec81dafd30f272565c37ab47a33b220684",
+                "sha256:6c06e4c6e234fcc65435223c7b2a90f286b7f1b2733058bdf1345d218cc59e34",
+                "sha256:6d0a8efc258659edc5299f9ef32d8d81de8b53b45d67bf4bfa3067f31366764d",
+                "sha256:70e5a10f8093d228bb2b552beeb318b8928b8a94763ef03b858ef3612b29395d",
+                "sha256:8394e652925a18ef0091115e3cc191fef350ab6dc3cc417f06da66bf98071ae9",
+                "sha256:8636cd2fc5da0fb102a2504fa2c4bea3cbc149533b345d72cdf0e7a924decc45",
+                "sha256:93df44ab351119d14cd1e6b52a5063d3336f0754b72736cc63db59307dabb718",
+                "sha256:96ba37c2e24b7212a77da85004c38e7c4d155d3e72a45eeaf22c1f03f607e8ab",
+                "sha256:a10dab5ea1bd4401c9483450b5b0ba5416be799bbd50fc7a6cc5e2a15e03e8a3",
+                "sha256:a66045af6cf00e19d02191ab578a50cb93b2028c3eefed999793698e9ea768ae",
+                "sha256:a75cc163a5f4531a256f2c523bd80db509a49fc23721b36dd1ef2f60ff41c3cb",
+                "sha256:b04c2f0adaf255bf756cf08ebef1be132d3c7a06fe6f9877d55640c5e60c72c5",
+                "sha256:ba42e3810999a0ddd0439e6e5dbf6d034055cdc72b7c5c839f37a7c274cb4eba",
+                "sha256:bfc8a5e9238232a45ebc5cb3bfee71f1167064c8d382cadd6076f0d51cff1da0",
+                "sha256:c5bd5680f844c3ff0008523a71949a3ff5e4953eb7701b28760805bc9bcff217",
+                "sha256:c84fdf3da00c2827d634de4fcf17e3e067490c4aea82833625c4c8e6cdea0887",
+                "sha256:ca6fab080484e419528e98624fb5c4282148b847e3602dc8dbe0cb0669469887",
+                "sha256:d0c188ae66b772d9d61d43c6030500344c13e3f73a00d1dc241da896f379bb62",
+                "sha256:d6ab42f223e58b7dac1bb0af32194a7b9311065583cc75ff59dcf301afd8a431",
+                "sha256:dfe80c017973e6a4c367e037cb31601044dd55e6bfacd57370674867d15a899b",
+                "sha256:e0c02b75acfea5cab07585d25069207e478d12309557f90a61b5a3b4f77f46ce",
+                "sha256:e30aaf2b8a2bac57eb7e1650df1b3a4130e8d0c66fc2f861039d507a11760e1b",
+                "sha256:eafbef886566dc1047d7b3d4b14db0d5b7deb99638d8e1be4e23a7c7ac59ff0f",
+                "sha256:efe0fab26d598e1ec07d72cf03eaeeba8e42b4ecf6b9ccb5a356fde60ff08b85",
+                "sha256:f08e469821a5e4751c97fcd34bcb586bc243c39c2e39321822060ba902eac49e",
+                "sha256:f1eaac5257a8f8a047248d60e8f9315c6cff58f7803971170d952555ef6344a7",
+                "sha256:f29fb0b3f1217dfe9362ec55440d0743fe868497359f2cf93293f4b2701b8251",
+                "sha256:f44d78b61740e4e8c71db1cf1fd56d9050a4747681c59ec1094750a658ceb970",
+                "sha256:f6aec19457617ef468ff091669cca01fa7ea557b12b59a7908b9474bb9674cf0",
+                "sha256:f9dc7f933975367251c1b34da882c4f0e0b2e24bb35dc906d2f598a40b72bfc7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.1"
+        },
+        "cycler": {
+            "hashes": [
+                "sha256:7896994252d006771357777d0251f3e34d266f4fa5f2c572247a80ab01440947",
+                "sha256:8cc3a7b4861f91b1095157f9916f748549a617046e67eb7619abed9b34d2c94a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.0"
+        },
+        "cython": {
+            "hashes": [
+                "sha256:011c4e0b75baee1843334562487eb4fbc0c59ddb2cc32a978b972a81eedcbdcc",
+                "sha256:05cb2a73810f045d328b7579cf98f550a9e601df5e282d1fea0512d8ad589011",
+                "sha256:067b2b9eb487bd61367b296f11b7c1c70a084b3eb7d5a572f607cd1fc5ca5586",
+                "sha256:08d67c7225a09eeb77e090c8d4f60677165b052ccf76e3a57d8237064e5c2de2",
+                "sha256:10cbfb37f31938371a6213cc8b5459c639954aed053efeded3c012d4c5915db9",
+                "sha256:147cc1d3dda8b06de9d86df5e59cdf15f0a522620168b7349a5ec88b48104d7d",
+                "sha256:1b12a8f23270675b537d1c3b988f845bea4bbcc66ae0468857f5ede0526d4522",
+                "sha256:213ff9f95de319e54b520bf31edd6aa7a1fa4fbf617c2beb0f92362595e6476a",
+                "sha256:22ba78e48bdb65977928ecb275ac8c82df7b0eefa075078a1363a5af4606b42e",
+                "sha256:2f84bd6cefa5130750c492038170c44f1cbd6f42e9ed85e168fd9cb453f85160",
+                "sha256:302281b927409b3e0ef8cd9251eab782cf1acd2578eab305519fbae5d184b7e9",
+                "sha256:34f7b014ebce5d325c8084e396c81cdafbd8d82be56780dffe6b67b28c891f1b",
+                "sha256:38085523fa7a299638d051ae08144222785639882f6291bd275c0b12db1034ff",
+                "sha256:477cd3549597f09a1608da7b05e16ba641e9aedd171b868533a5a07790ed886f",
+                "sha256:4bebbca13078125a35937966137af4bd0300a0c66fd7ae4ce36adc049b13bdf3",
+                "sha256:4db017b104f47b1185237702f6ed2651839c8124614683efa7c489f3fa4e19d9",
+                "sha256:4dca13c86d6cd523c7d8bbf8db1b2bbf8faedd0addedb229158d8015ad1819e1",
+                "sha256:4fe806d154b6b7f0ab746dac36c022889e2e7cf47546ff9afdc29a62cfa692d0",
+                "sha256:54d41a1dfbaab74449873e7f8e6cd4239850fe7a50f7f784dd99a560927f3bac",
+                "sha256:550b3fbe9b3c555b44ded934f4822f9fcc04dfcee512167ebcbbd370ccede20e",
+                "sha256:5682293d344b7dbad97ce6eceb9e887aca6e53499709db9da726ca3424e5559d",
+                "sha256:62dd78afdf748a58dae9c9b9c42a1519ae30787b28ce5f84a0e1bb54144142ca",
+                "sha256:6b75e9c9d7ad7c9dd85d45241d1d4e3c5f66079c1f84eec91689c26d98bc3349",
+                "sha256:75a2395cc7b78cff59be6e9b7f92bbb5d7b8d25203f6d3fb6f72bdb7d3f49777",
+                "sha256:77ec0134fc1b10aebef2013936a91c07bff2498ec283bc2eca099ee0cb94d12e",
+                "sha256:786b6034a91e886116bb562fe42f8bf0f97c3e00c02e56791d02675959ed65b1",
+                "sha256:78e2853d484643c6b7ac3bdb48392753442da1c71b689468fa3176b619bebe54",
+                "sha256:7e08ff5da5f5b969639784b1bffcd880a0c0f048d182aed7cba9945ee8b367c2",
+                "sha256:7f43c4d3ecd9e3b8b7afe834e519f55cf4249b1088f96d11b96f02c55cbaeff7",
+                "sha256:809617cf4825b2138ce0ec827e1f28e39668743c81ac8286373f8d148c05f088",
+                "sha256:832bbee87bca760efeae248ddf19ccd77f9a2355cb6f8a64f20cc377e56957b3",
+                "sha256:8850269ff59f77a1629e26d0576701925360d732011d6d3516ccdc5b2c2bc310",
+                "sha256:8948504338d7a140ce588333177dcabf0743a68dbc83b0174f214f5b959634d5",
+                "sha256:8ccb91d2254e34724f1541b2a6fcdfacdb88284185b0097ae84e0ddf476c7a38",
+                "sha256:8f1c9e4b8e413da211dd7942440cf410ff0eafb081309e04e81f4fafbb146bf2",
+                "sha256:9594818dca8bb22ae6580c5222da2bc5cc32334350bd2d294a00d8669bcc61b5",
+                "sha256:989787fc24a95100a26918b6577d06e15a8868a3ed267009c5cfcf1a906179ac",
+                "sha256:9e625eec8c5c9a8cb062a318b257cc469d301bed952c7daf86e38bbd3afe7c91",
+                "sha256:a1c3675394b81024aaf56e4f53c2b4f81d9a116c7049e9d4706f810899c9134e",
+                "sha256:a49dde9f9e29ea82f29aaf3bb1a270b6eb90b75d627c7ff2f5dd3764540ae646",
+                "sha256:a51efba0e136b2af358e5a347bae09678b17460c35cf1eab24f0476820348991",
+                "sha256:ae453cfa933b919c0a19d2cc5dc9fb28486268e95dc2ab7a11ab7f99cf8c3883",
+                "sha256:b032cb0c69082f0665b2c5fb416d041157062f1538336d0edf823b9ee500e39c",
+                "sha256:b1f023d36a3829069ed11017c670128be3f135a9c17bd64c35d3b3442243b05c",
+                "sha256:bc1c8013fad0933f5201186eccc5f2be223cafd6a8dcd586d3f7bb6ba84dc845",
+                "sha256:c298b1589205ecaaed0457ad05e0c8a43e7db2053607f48ed4a899cb6aa114df",
+                "sha256:c5e722732e9aa9bde667ed6d87525234823eb7766ca234cfb19d7e0c095a2ef4",
+                "sha256:c90eeb94395315e65fd758a2f86b92904fce7b50060b4d45a878ef6767f9276e",
+                "sha256:cc9d173ab8b167cae674f6deed8c65ba816574797a2bd6d8aa623277d1fa81ca",
+                "sha256:d0d0cc4ecc05f41c5e02af14ac0083552d22efed976f79eb7bade55fed63b25d",
+                "sha256:d21801981db44b7e9f9768f121317946461d56b51de1e6eff3c42e8914048696",
+                "sha256:d5e5587128e8c2423aefcffa4ded4ddf60d44898938fbb7c0f236636a750a94f",
+                "sha256:dab6a923e21e212aa3dc6dde9b22a190f5d7c449315a94e57ddc019ea74a979b",
+                "sha256:dd30826ca8b27b2955a63c8ffe8aacc9f0779582b4bd154cf7b441ac10dae2cb",
+                "sha256:e486331a29e7700b1ad5f4f753bef483c81412a5e64a873df46d6cb66f9a65de",
+                "sha256:e663c237579c033deaa2cb362b74651da7712f56e441c11382510a8c4c4f2dd7",
+                "sha256:e825e682cef76d0c33384f38b56b7e87c76152482a914dfc78faed6ff66ce05a",
+                "sha256:f37e4287f520f3748a06ad5eaae09ba4ac68f52e155d70de5f75780d83575c43"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4",
+                "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.12.4"
+        },
+        "fonttools": {
+            "hashes": [
+                "sha256:030355fbb0cea59cf75d076d04d3852900583d1258574ff2d7d719abf4513836",
+                "sha256:05056a8c9af048381fdb17e89b17d45f6c8394176d01e8c6fef5ac96ea950d38",
+                "sha256:206808f9717c9b19117f461246372a2c160fa12b9b8dbdfb904ab50ca235ba0a",
+                "sha256:20fc43783c432862071fa76da6fa714902ae587bc68441e12ff4099b94b1fcef",
+                "sha256:25620b738d4533cfc21fd2a4f4b667e481f7cb60e86b609799f7d98af657854e",
+                "sha256:33c40a657fb87ff83185828c0323032d63a4df1279d5c1c38e21f3ec56327803",
+                "sha256:3d7adfa342e6b3a2b36960981f23f480969f833d565a4eba259c2e6f59d2674f",
+                "sha256:48078357984214ccd22d7fe0340cd6ff7286b2f74f173603a1a9a40b5dc25afe",
+                "sha256:5056f69a18f3f28ab5283202d1efcfe011585d31de09d8560f91c6c88f041e92",
+                "sha256:52e77f23a9c059f8be01a07300ba4c4d23dc271d33eed502aea5a01ab5d2f4c1",
+                "sha256:57c22e5f9f53630d458830f710424dce4f43c5f0d95cb3368c0f5178541e4db7",
+                "sha256:5aa67d1e720fdd902fde4a59d0880854ae9f19fc958f3e1538bceb36f7f4dc92",
+                "sha256:5f9660e70a2430780e23830476332bc3391c3c8694769e2c0032a5038702a662",
+                "sha256:635658464dccff6fa5c3b43fe8f818ae2c386ee6a9e1abc27359d1e255528186",
+                "sha256:6a530fa28c155538d32214eafa0964989098a662bd63e91e790e6a7a4e9c02da",
+                "sha256:70f021a6b9eb10dfe7a411b78e63a503a06955dd6d2a4e130906d8760474f77c",
+                "sha256:77e5113233a2df07af9dbf493468ce526784c3b179c0e8b9c7838ced37c98b69",
+                "sha256:7c76f32051159f8284f1a5f5b605152b5a530736fb8b55b09957db38dcae5348",
+                "sha256:812142a0e53cc853964d487e6b40963df62f522b1b571e19d1ff8467d7880ceb",
+                "sha256:82d8e687a42799df5325e7ee12977b74738f34bf7fde1c296f8140efd699a213",
+                "sha256:8dfd8edfce34ad135bd69de20c77449c06e2c92b38f2a8358d0987737f82b49e",
+                "sha256:93c5b6d77baf28f306bc13fa987b0b13edca6a39dc2324eaca299a74ccc6316f",
+                "sha256:9d654d3e780e0ceabb1f4eff5a3c042c67d4428d0fe1ea3afd238a721cf171b3",
+                "sha256:a682fb5cbf8837d1822b80acc0be5ff2ea0c49ca836e468a21ffd388ef280fd3",
+                "sha256:a68b71adc3b3a90346e4ac92f0a69ab9caeba391f3b04ab6f1e98f2c8ebe88e3",
+                "sha256:a6a2e99bb9ea51e0974bbe71768df42c6dd189308c22f3f00560c3341b345646",
+                "sha256:ab80e7d6bb01316d5fc8161a2660ca2e9e597d0880db4927bc866c76474472ef",
+                "sha256:ace0fd5afb79849f599f76af5c6aa5e865bd042c811e4e047bbaa7752cc26126",
+                "sha256:ace51902ab67ef5fe225e8b361039e996db153e467e24a28d35f74849b37b7ce",
+                "sha256:af38f5145258e9866da5881580507e6d17ff7756beef175d13213a43a84244e9",
+                "sha256:b3813f57f85bbc0e4011a0e1e9211f9ee52f87f402e41dc05bc5135f03fa51c1",
+                "sha256:b5e760198f0b87e42478bb35a6eae385c636208f6f0d413e100b9c9c5efafb6a",
+                "sha256:b62a53a4ca83c32c6b78cac64464f88d02929779373c716f738af6968c8c821e",
+                "sha256:d08a694b280d615460563a6b4e2afb0b1b9df708c799ec212bf966652b94fc84",
+                "sha256:d27d960e10cf7617d70cf3104c32a69b008dde56f2d55a9bed4ba6e3df611544",
+                "sha256:da78f39b601ed0b4262929403186d65cf7a016f91ff349ab18fdc5a7080af465",
+                "sha256:dcc01cea0a121fb0c009993497bad93cae25e77db7dee5345fec9cce1aaa09cd",
+                "sha256:e3f8acc6ef4a627394021246e099faee4b343afd3ffe2e517d8195b4ebf20289",
+                "sha256:e4bc589d8da09267c7c4ceaaaa4fc01a7908ac5b43b286ac9279afe76407c384",
+                "sha256:e5d53eddaf436fa131042f44a76ea1ead0a17c354ab9de0d80e818f0cb1629f1",
+                "sha256:ee728d5af70f117581712966a21e2e07031e92c687ef1fdc457ac8d281016f64",
+                "sha256:f19c2b1c65d57cbea25cabb80941fea3fbf2625ff0cdcae8900b5fb1c145704f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.43.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "joblib": {
+            "hashes": [
+                "sha256:92f865e621e17784e7955080b6d042489e3b8e294949cc44c6eac304f59772b1",
+                "sha256:ef4331c65f239985f3f2220ecc87db222f08fd22097a3dd5698f693875f8cbb9"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.2"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:00bd361b903dc4bbf4eb165f24d1acbee754fce22ded24c3d56eec268658a5cf",
+                "sha256:040c1aebeda72197ef477a906782b5ab0d387642e93bda547336b8957c61022e",
+                "sha256:05703cf211d585109fcd72207a31bb170a0f22144d68298dc5e61b3c946518af",
+                "sha256:06f54715b7737c2fecdbf140d1afb11a33d59508a47bf11bb38ecf21dc9ab79f",
+                "sha256:0dc9db8e79f0036e8173c466d21ef18e1befc02de8bf8aa8dc0813a6dc8a7046",
+                "sha256:0f114aa76dc1b8f636d077979c0ac22e7cd8f3493abbab152f20eb8d3cda71f3",
+                "sha256:11863aa14a51fd6ec28688d76f1735f8f69ab1fabf388851a595d0721af042f5",
+                "sha256:11c7de8f692fc99816e8ac50d1d1aef4f75126eefc33ac79aac02c099fd3db71",
+                "sha256:11d011a7574eb3b82bcc9c1a1d35c1d7075677fdd15de527d91b46bd35e935ee",
+                "sha256:146d14bebb7f1dc4d5fbf74f8a6cb15ac42baadee8912eb84ac0b3b2a3dc6ac3",
+                "sha256:15568384086b6df3c65353820a4473575dbad192e35010f622c6ce3eebd57af9",
+                "sha256:19df6e621f6d8b4b9c4d45f40a66839294ff2bb235e64d2178f7522d9170ac5b",
+                "sha256:1b04139c4236a0f3aff534479b58f6f849a8b351e1314826c2d230849ed48985",
+                "sha256:210ef2c3a1f03272649aff1ef992df2e724748918c4bc2d5a90352849eb40bea",
+                "sha256:2270953c0d8cdab5d422bee7d2007f043473f9d2999631c86a223c9db56cbd16",
+                "sha256:2400873bccc260b6ae184b2b8a4fec0e4082d30648eadb7c3d9a13405d861e89",
+                "sha256:2a40773c71d7ccdd3798f6489aaac9eee213d566850a9533f8d26332d626b82c",
+                "sha256:2c5674c4e74d939b9d91dda0fae10597ac7521768fec9e399c70a1f27e2ea2d9",
+                "sha256:3195782b26fc03aa9c6913d5bad5aeb864bdc372924c093b0f1cebad603dd712",
+                "sha256:31a82d498054cac9f6d0b53d02bb85811185bcb477d4b60144f915f3b3126342",
+                "sha256:32d5cf40c4f7c7b3ca500f8985eb3fb3a7dfc023215e876f207956b5ea26632a",
+                "sha256:346f5343b9e3f00b8db8ba359350eb124b98c99efd0b408728ac6ebf38173958",
+                "sha256:378a214a1e3bbf5ac4a8708304318b4f890da88c9e6a07699c4ae7174c09a68d",
+                "sha256:39b42c68602539407884cf70d6a480a469b93b81b7701378ba5e2328660c847a",
+                "sha256:3a2b053a0ab7a3960c98725cfb0bf5b48ba82f64ec95fe06f1d06c99b552e130",
+                "sha256:3aba7311af82e335dd1e36ffff68aaca609ca6290c2cb6d821a39aa075d8e3ff",
+                "sha256:3cd32d6c13807e5c66a7cbb79f90b553642f296ae4518a60d8d76243b0ad2898",
+                "sha256:3edd2fa14e68c9be82c5b16689e8d63d89fe927e56debd6e1dbce7a26a17f81b",
+                "sha256:4c380469bd3f970ef677bf2bcba2b6b0b4d5c75e7a020fb863ef75084efad66f",
+                "sha256:4e66e81a5779b65ac21764c295087de82235597a2293d18d943f8e9e32746265",
+                "sha256:53abb58632235cd154176ced1ae8f0d29a6657aa1aa9decf50b899b755bc2b93",
+                "sha256:5794cf59533bc3f1b1c821f7206a3617999db9fbefc345360aafe2e067514929",
+                "sha256:59415f46a37f7f2efeec758353dd2eae1b07640d8ca0f0c42548ec4125492635",
+                "sha256:59ec7b7c7e1a61061850d53aaf8e93db63dce0c936db1fda2658b70e4a1be709",
+                "sha256:59edc41b24031bc25108e210c0def6f6c2191210492a972d585a06ff246bb79b",
+                "sha256:5a580c91d686376f0f7c295357595c5a026e6cbc3d77b7c36e290201e7c11ecb",
+                "sha256:5b94529f9b2591b7af5f3e0e730a4e0a41ea174af35a4fd067775f9bdfeee01a",
+                "sha256:5c7b3b3a728dc6faf3fc372ef24f21d1e3cee2ac3e9596691d746e5a536de920",
+                "sha256:5c90ae8c8d32e472be041e76f9d2f2dbff4d0b0be8bd4041770eddb18cf49a4e",
+                "sha256:5e7139af55d1688f8b960ee9ad5adafc4ac17c1c473fe07133ac092310d76544",
+                "sha256:5ff5cf3571589b6d13bfbfd6bcd7a3f659e42f96b5fd1c4830c4cf21d4f5ef45",
+                "sha256:620ced262a86244e2be10a676b646f29c34537d0d9cc8eb26c08f53d98013390",
+                "sha256:6512cb89e334e4700febbffaaa52761b65b4f5a3cf33f960213d5656cea36a77",
+                "sha256:6c08e1312a9cf1074d17b17728d3dfce2a5125b2d791527f33ffbe805200a355",
+                "sha256:6c3bd3cde54cafb87d74d8db50b909705c62b17c2099b8f2e25b461882e544ff",
+                "sha256:6ef7afcd2d281494c0a9101d5c571970708ad911d028137cd558f02b851c08b4",
+                "sha256:7269d9e5f1084a653d575c7ec012ff57f0c042258bf5db0954bf551c158466e7",
+                "sha256:72d40b33e834371fd330fb1472ca19d9b8327acb79a5821d4008391db8e29f20",
+                "sha256:74d1b44c6cfc897df648cc9fdaa09bc3e7679926e6f96df05775d4fb3946571c",
+                "sha256:74db36e14a7d1ce0986fa104f7d5637aea5c82ca6326ed0ec5694280942d1162",
+                "sha256:763773d53f07244148ccac5b084da5adb90bfaee39c197554f01b286cf869228",
+                "sha256:76c6a5964640638cdeaa0c359382e5703e9293030fe730018ca06bc2010c4437",
+                "sha256:76d9289ed3f7501012e05abb8358bbb129149dbd173f1f57a1bf1c22d19ab7cc",
+                "sha256:7931d8f1f67c4be9ba1dd9c451fb0eeca1a25b89e4d3f89e828fe12a519b782a",
+                "sha256:7b8b454bac16428b22560d0a1cf0a09875339cab69df61d7805bf48919415901",
+                "sha256:7e5bab140c309cb3a6ce373a9e71eb7e4873c70c2dda01df6820474f9889d6d4",
+                "sha256:83d78376d0d4fd884e2c114d0621624b73d2aba4e2788182d286309ebdeed770",
+                "sha256:852542f9481f4a62dbb5dd99e8ab7aedfeb8fb6342349a181d4036877410f525",
+                "sha256:85267bd1aa8880a9c88a8cb71e18d3d64d2751a790e6ca6c27b8ccc724bcd5ad",
+                "sha256:88a2df29d4724b9237fc0c6eaf2a1adae0cdc0b3e9f4d8e7dc54b16812d2d81a",
+                "sha256:88b9f257ca61b838b6f8094a62418421f87ac2a1069f7e896c36a7d86b5d4c29",
+                "sha256:8ab3919a9997ab7ef2fbbed0cc99bb28d3c13e6d4b1ad36e97e482558a91be90",
+                "sha256:92dea1ffe3714fa8eb6a314d2b3c773208d865a0e0d35e713ec54eea08a66250",
+                "sha256:9407b6a5f0d675e8a827ad8742e1d6b49d9c1a1da5d952a67d50ef5f4170b18d",
+                "sha256:9408acf3270c4b6baad483865191e3e582b638b1654a007c62e3efe96f09a9a3",
+                "sha256:955e8513d07a283056b1396e9a57ceddbd272d9252c14f154d450d227606eb54",
+                "sha256:9db8ea4c388fdb0f780fe91346fd438657ea602d58348753d9fb265ce1bca67f",
+                "sha256:9eaa8b117dc8337728e834b9c6e2611f10c79e38f65157c4c38e9400286f5cb1",
+                "sha256:a51a263952b1429e429ff236d2f5a21c5125437861baeed77f5e1cc2d2c7c6da",
+                "sha256:a6aa6315319a052b4ee378aa171959c898a6183f15c1e541821c5c59beaa0238",
+                "sha256:aa12042de0171fad672b6c59df69106d20d5596e4f87b5e8f76df757a7c399aa",
+                "sha256:aaf7be1207676ac608a50cd08f102f6742dbfc70e8d60c4db1c6897f62f71523",
+                "sha256:b0157420efcb803e71d1b28e2c287518b8808b7cf1ab8af36718fd0a2c453eb0",
+                "sha256:b3f7e75f3015df442238cca659f8baa5f42ce2a8582727981cbfa15fee0ee205",
+                "sha256:b9098e0049e88c6a24ff64545cdfc50807818ba6c1b739cae221bbbcbc58aad3",
+                "sha256:ba55dce0a9b8ff59495ddd050a0225d58bd0983d09f87cfe2b6aec4f2c1234e4",
+                "sha256:bb86433b1cfe686da83ce32a9d3a8dd308e85c76b60896d58f082136f10bffac",
+                "sha256:bbea0db94288e29afcc4c28afbf3a7ccaf2d7e027489c449cf7e8f83c6346eb9",
+                "sha256:bbf1d63eef84b2e8c89011b7f2235b1e0bf7dacc11cac9431fc6468e99ac77fb",
+                "sha256:c7940c1dc63eb37a67721b10d703247552416f719c4188c54e04334321351ced",
+                "sha256:c9bf3325c47b11b2e51bca0824ea217c7cd84491d8ac4eefd1e409705ef092bd",
+                "sha256:cdc8a402aaee9a798b50d8b827d7ecf75edc5fb35ea0f91f213ff927c15f4ff0",
+                "sha256:ceec1a6bc6cab1d6ff5d06592a91a692f90ec7505d6463a88a52cc0eb58545da",
+                "sha256:cfe6ab8da05c01ba6fbea630377b5da2cd9bcbc6338510116b01c1bc939a2c18",
+                "sha256:d099e745a512f7e3bbe7249ca835f4d357c586d78d79ae8f1dcd4d8adeb9bda9",
+                "sha256:d0ef46024e6a3d79c01ff13801cb19d0cad7fd859b15037aec74315540acc276",
+                "sha256:d2e5a98f0ec99beb3c10e13b387f8db39106d53993f498b295f0c914328b1333",
+                "sha256:da4cfb373035def307905d05041c1d06d8936452fe89d464743ae7fb8371078b",
+                "sha256:da802a19d6e15dffe4b0c24b38b3af68e6c1a68e6e1d8f30148c83864f3881db",
+                "sha256:dced8146011d2bc2e883f9bd68618b8247387f4bbec46d7392b3c3b032640126",
+                "sha256:dfdd7c0b105af050eb3d64997809dc21da247cf44e63dc73ff0fd20b96be55a9",
+                "sha256:e368f200bbc2e4f905b8e71eb38b3c04333bddaa6a2464a6355487b02bb7fb09",
+                "sha256:e391b1f0a8a5a10ab3b9bb6afcfd74f2175f24f8975fb87ecae700d1503cdee0",
+                "sha256:e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec",
+                "sha256:e5d706eba36b4c4d5bc6c6377bb6568098765e990cfc21ee16d13963fab7b3e7",
+                "sha256:ec20916e7b4cbfb1f12380e46486ec4bcbaa91a9c448b97023fde0d5bbf9e4ff",
+                "sha256:f1d072c2eb0ad60d4c183f3fb44ac6f73fb7a8f16a2694a91f988275cbf352f9",
+                "sha256:f846c260f483d1fd217fe5ed7c173fb109efa6b1fc8381c8b7552c5781756192",
+                "sha256:f91de7223d4c7b793867797bacd1ee53bfe7359bd70d27b7b58a04efbb9436c8",
+                "sha256:faae4860798c31530dd184046a900e652c95513796ef51a12bc086710c2eec4d",
+                "sha256:fc579bf0f502e54926519451b920e875f433aceb4624a3646b3252b5caa9e0b6",
+                "sha256:fcc700eadbbccbf6bc1bcb9dbe0786b4b1cb91ca0dcda336eef5c2beed37b797",
+                "sha256:fd32ea360bcbb92d28933fc05ed09bffcb1704ba3fc7942e81db0fd4f81a7892",
+                "sha256:fdb7adb641a0d13bdcd4ef48e062363d8a9ad4a182ac7647ec88f695e719ae9f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.4.5"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
+                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
+                "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
+                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
+                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
+                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
+                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
+                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
+                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
+                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+                "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
+                "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.3"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:061ee58facb3580cd2d046a6d227fb77e9295599c5ec6ad069f06b5821ad1cfc",
+                "sha256:0b11f354aae62a2aa53ec5bb09946f5f06fc41793e351a04ff60223ea9162955",
+                "sha256:0d5ee602ef517a89d1f2c508ca189cfc395dd0b4a08284fb1b97a78eec354644",
+                "sha256:0e723f5b96f3cd4aad99103dc93e9e3cdc4f18afdcc76951f4857b46f8e39d2d",
+                "sha256:23ed11654fc83cd6cfdf6170b453e437674a050a452133a064d47f2f1371f8d3",
+                "sha256:2ea6886e93401c22e534bbfd39201ce8931b75502895cfb115cbdbbe2d31f287",
+                "sha256:31e793c8bd4ea268cc5d3a695c27b30650ec35238626961d73085d5e94b6ab68",
+                "sha256:36eafe2128772195b373e1242df28d1b7ec6c04c15b090b8d9e335d55a323900",
+                "sha256:3cc3776836d0f4f22654a7f2d2ec2004618d5cf86b7185318381f73b80fd8a2d",
+                "sha256:5dc945a9cb2deb7d197ba23eb4c210e591d52d77bf0ba27c35fc82dec9fa78d4",
+                "sha256:5de39dc61ca35342cf409e031f70f18219f2c48380d3886c1cf5ad9f17898e06",
+                "sha256:60a6e04dfd77c0d3bcfee61c3cd335fff1b917c2f303b32524cd1235e194ef99",
+                "sha256:6c49a2bd6981264bddcb8c317b6bd25febcece9e2ebfcbc34e7f4c0c867c09dc",
+                "sha256:6f25ffb6ad972cdffa7df8e5be4b1e3cadd2f8d43fc72085feb1518006178394",
+                "sha256:7b37b74f00c4cb6af908cb9a00779d97d294e89fd2145ad43f0cdc23f635760c",
+                "sha256:7f54b9fb87ca5acbcdd0f286021bedc162e1425fa5555ebf3b3dfc167b955ad9",
+                "sha256:87df75f528020a6299f76a1d986c0ed4406e3b2bd44bc5e306e46bca7d45e53e",
+                "sha256:90d74a95fe055f73a6cd737beecc1b81c26f2893b7a3751d52b53ff06ca53f36",
+                "sha256:a33bd3045c7452ca1fa65676d88ba940867880e13e2546abb143035fa9072a9d",
+                "sha256:c3499c312f5def8f362a2bf761d04fa2d452b333f3a9a3f58805273719bf20d9",
+                "sha256:c4940bad88a932ddc69734274f6fb047207e008389489f2b6f77d9ca485f0e7a",
+                "sha256:d670b9348e712ec176de225d425f150dc8e37b13010d85233c539b547da0be39",
+                "sha256:dae97fdd6996b3a25da8ee43e3fc734fff502f396801063c6b76c20b56683196",
+                "sha256:dd386c80a98b5f51571b9484bf6c6976de383cd2a8cd972b6a9562d85c6d2087",
+                "sha256:df8505e1c19d5c2c26aff3497a7cbd3ccfc2e97043d1e4db3e76afa399164b69",
+                "sha256:eee482731c8c17d86d9ddb5194d38621f9b0f0d53c99006275a12523ab021732",
+                "sha256:f691b4ef47c7384d0936b2e8ebdeb5d526c81d004ad9403dfb9d4c76b9979a93",
+                "sha256:f8b5a1bf27d078453aa7b5b27f52580e16360d02df6d3dc9504f3d2ce11f6309"
+            ],
+            "index": "pypi",
+            "version": "==3.8.0"
+        },
+        "mpmath": {
+            "hashes": [
+                "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f",
+                "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"
+            ],
+            "version": "==1.3.0"
+        },
+        "networkx": {
+            "hashes": [
+                "sha256:4f33f68cb2afcf86f28a45f43efc27a9386b535d567d2127f8f61d51dec58d36",
+                "sha256:de346335408f84de0eada6ff9fafafff9bcda11f0a0dfaa931133debb146ab61"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:020cdbee66ed46b671429c7265cf00d8ac91c046901c55684954c3958525dab2",
+                "sha256:0621f7daf973d34d18b4e4bafb210bbaf1ef5e0100b5fa750bd9cde84c7ac292",
+                "sha256:0792824ce2f7ea0c82ed2e4fecc29bb86bee0567a080dacaf2e0a01fe7654369",
+                "sha256:09aaee96c2cbdea95de76ecb8a586cb687d281c881f5f17bfc0fb7f5890f6b91",
+                "sha256:166b36197e9debc4e384e9c652ba60c0bacc216d0fc89e78f973a9760b503388",
+                "sha256:186ba67fad3c60dbe8a3abff3b67a91351100f2661c8e2a80364ae6279720299",
+                "sha256:306545e234503a24fe9ae95ebf84d25cba1fdc27db971aa2d9f1ab6bba19a9dd",
+                "sha256:436c8e9a4bdeeee84e3e59614d38c3dbd3235838a877af8c211cfcac8a80b8d3",
+                "sha256:4a873a8180479bc829313e8d9798d5234dfacfc2e8a7ac188418189bb8eafbd2",
+                "sha256:4acc65dd65da28060e206c8f27a573455ed724e6179941edb19f97e58161bb69",
+                "sha256:51be5f8c349fdd1a5568e72713a21f518e7d6707bcf8503b528b88d33b57dc68",
+                "sha256:546b7dd7e22f3c6861463bebb000646fa730e55df5ee4a0224408b5694cc6148",
+                "sha256:5671338034b820c8d58c81ad1dafc0ed5a00771a82fccc71d6438df00302094b",
+                "sha256:637c58b468a69869258b8ae26f4a4c6ff8abffd4a8334c830ffb63e0feefe99a",
+                "sha256:767254ad364991ccfc4d81b8152912e53e103ec192d1bb4ea6b1f5a7117040be",
+                "sha256:7d484292eaeb3e84a51432a94f53578689ffdea3f90e10c8b203a99be5af57d8",
+                "sha256:7f6bad22a791226d0a5c7c27a80a20e11cfe09ad5ef9084d4d3fc4a299cca505",
+                "sha256:86f737708b366c36b76e953c46ba5827d8c27b7a8c9d0f471810728e5a2fe57c",
+                "sha256:8c6adc33561bd1d46f81131d5352348350fc23df4d742bb246cdfca606ea1208",
+                "sha256:914b28d3215e0c721dc75db3ad6d62f51f630cb0c277e6b3bcb39519bed10bd8",
+                "sha256:b44e6a09afc12952a7d2a58ca0a2429ee0d49a4f89d83a0a11052da696440e49",
+                "sha256:bb0d9a1aaf5f1cb7967320e80690a1d7ff69f1d47ebc5a9bea013e3a21faec95",
+                "sha256:c0b45c8b65b79337dee5134d038346d30e109e9e2e9d43464a2970e5c0e93229",
+                "sha256:c2e698cb0c6dda9372ea98a0344245ee65bdc1c9dd939cceed6bb91256837896",
+                "sha256:c78a22e95182fb2e7874712433eaa610478a3caf86f28c621708d35fa4fd6e7f",
+                "sha256:e062aa24638bb5018b7841977c360d2f5917268d125c833a686b7cbabbec496c",
+                "sha256:e5e18e5b14a7560d8acf1c596688f4dfd19b4f2945b245a71e5af4ddb7422feb",
+                "sha256:eae430ecf5794cb7ae7fa3808740b015aa80747e5266153128ef055975a72b99",
+                "sha256:ee84ca3c58fe48b8ddafdeb1db87388dce2c3c3f701bf447b05e4cfcc3679112",
+                "sha256:f042f66d0b4ae6d48e70e28d487376204d3cbf43b84c03bac57e28dac6151581",
+                "sha256:f8db2f125746e44dce707dd44d4f4efeea8d7e2b43aace3f8d1f235cfa2733dd",
+                "sha256:f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"
+            ],
+            "index": "pypi",
+            "version": "==1.26.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:02304e11582c5d090e5a52aec726f31fe3f42895d6bfc1f28738f9b64b6f0614",
+                "sha256:0489b0e6aa3d907e909aef92975edae89b1ee1654db5eafb9be633b0124abe97",
+                "sha256:05674536bd477af36aa2effd4ec8f71b92234ce0cc174de34fd21e2ee99adbc2",
+                "sha256:25e8474a8eb258e391e30c288eecec565bfed3e026f312b0cbd709a63906b6f8",
+                "sha256:29deb61de5a8a93bdd033df328441a79fcf8dd3c12d5ed0b41a395eef9cd76f0",
+                "sha256:366da7b0e540d1b908886d4feb3d951f2f1e572e655c1160f5fde28ad4abb750",
+                "sha256:3bcad1e6fb34b727b016775bea407311f7721db87e5b409e6542f4546a4951ea",
+                "sha256:4c3f32fd7c4dccd035f71734df39231ac1a6ff95e8bdab8d891167197b7018d2",
+                "sha256:4cdb0fab0400c2cb46dafcf1a0fe084c8bb2480a1fa8d81e19d15e12e6d4ded2",
+                "sha256:4f99bebf19b7e03cf80a4e770a3e65eee9dd4e2679039f542d7c1ace7b7b1daa",
+                "sha256:58d997dbee0d4b64f3cb881a24f918b5f25dd64ddf31f467bb9b67ae4c63a1e4",
+                "sha256:75ce97667d06d69396d72be074f0556698c7f662029322027c226fd7a26965cb",
+                "sha256:84e7e910096416adec68075dc87b986ff202920fb8704e6d9c8c9897fe7332d6",
+                "sha256:9e2959720b70e106bb1d8b6eadd8ecd7c8e99ccdbe03ee03260877184bb2877d",
+                "sha256:9e50e72b667415a816ac27dfcfe686dc5a0b02202e06196b943d54c4f9c7693e",
+                "sha256:a0dbfea0dd3901ad4ce2306575c54348d98499c95be01b8d885a2737fe4d7a98",
+                "sha256:b407381258a667df49d58a1b637be33e514b07f9285feb27769cedb3ab3d0b3a",
+                "sha256:b8bd1685556f3374520466998929bade3076aeae77c3e67ada5ed2b90b4de7f0",
+                "sha256:c1f84c144dee086fe4f04a472b5cd51e680f061adf75c1ae4fc3a9275560f8f4",
+                "sha256:c747793c4e9dcece7bb20156179529898abf505fe32cb40c4052107a3c620b49",
+                "sha256:cc1ab6a25da197f03ebe6d8fa17273126120874386b4ac11c1d687df288542dd",
+                "sha256:dc3657869c7902810f32bd072f0740487f9e030c1a3ab03e0af093db35a9d14e",
+                "sha256:f5ec7740f9ccb90aec64edd71434711f58ee0ea7f5ed4ac48be11cfa9abf7317",
+                "sha256:fecb198dc389429be557cde50a2d46da8434a17fe37d7d41ff102e3987fd947b",
+                "sha256:ffa8f0966de2c22de408d0e322db2faed6f6e74265aa0856f3824813cf124363"
+            ],
+            "index": "pypi",
+            "version": "==2.1.1"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:0462b1496505a3462d0f35dc1c4d7b54069747d65d00ef48e736acda2c8cbdff",
+                "sha256:186f7e04248103482ea6354af6d5bcedb62941ee08f7f788a1c7707bc720c66f",
+                "sha256:19e9adb3f22d4c416e7cd79b01375b17159d6990003633ff1d8377e21b7f1b21",
+                "sha256:28444cb6ad49726127d6b340217f0627abc8732f1194fd5352dec5e6a0105635",
+                "sha256:2872f2d7846cf39b3dbff64bc1104cc48c76145854256451d33c5faa55c04d1a",
+                "sha256:2cc6b86ece42a11f16f55fe8903595eff2b25e0358dec635d0a701ac9586588f",
+                "sha256:2d7e91b4379f7a76b31c2dda84ab9e20c6220488e50f7822e59dac36b0cd92b1",
+                "sha256:2fa6dd2661838c66f1a5473f3b49ab610c98a128fc08afbe81b91a1f0bf8c51d",
+                "sha256:32bec7423cdf25c9038fef614a853c9d25c07590e1a870ed471f47fb80b244db",
+                "sha256:3855447d98cced8670aaa63683808df905e956f00348732448b5a6df67ee5849",
+                "sha256:3a04359f308ebee571a3127fdb1bd01f88ba6f6fb6d087f8dd2e0d9bff43f2a7",
+                "sha256:3a0d3e54ab1df9df51b914b2233cf779a5a10dfd1ce339d0421748232cea9876",
+                "sha256:44e7e4587392953e5e251190a964675f61e4dae88d1e6edbe9f36d6243547ff3",
+                "sha256:459307cacdd4138edee3875bbe22a2492519e060660eaf378ba3b405d1c66317",
+                "sha256:4ce90f8a24e1c15465048959f1e94309dfef93af272633e8f37361b824532e91",
+                "sha256:50bd5f1ebafe9362ad622072a1d2f5850ecfa44303531ff14353a4059113b12d",
+                "sha256:522ff4ac3aaf839242c6f4e5b406634bfea002469656ae8358644fc6c4856a3b",
+                "sha256:552912dbca585b74d75279a7570dd29fa43b6d93594abb494ebb31ac19ace6bd",
+                "sha256:5d6c9049c6274c1bb565021367431ad04481ebb54872edecfcd6088d27edd6ed",
+                "sha256:697a06bdcedd473b35e50a7e7506b1d8ceb832dc238a336bd6f4f5aa91a4b500",
+                "sha256:71671503e3015da1b50bd18951e2f9daf5b6ffe36d16f1eb2c45711a301521a7",
+                "sha256:723bd25051454cea9990203405fa6b74e043ea76d4968166dfd2569b0210886a",
+                "sha256:764d2c0daf9c4d40ad12fbc0abd5da3af7f8aa11daf87e4fa1b834000f4b6b0a",
+                "sha256:787bb0169d2385a798888e1122c980c6eff26bf941a8ea79747d35d8f9210ca0",
+                "sha256:7f771e7219ff04b79e231d099c0a28ed83aa82af91fd5fa9fdb28f5b8d5addaf",
+                "sha256:847e8d1017c741c735d3cd1883fa7b03ded4f825a6e5fcb9378fd813edee995f",
+                "sha256:84efb46e8d881bb06b35d1d541aa87f574b58e87f781cbba8d200daa835b42e1",
+                "sha256:898f1d306298ff40dc1b9ca24824f0488f6f039bc0e25cfb549d3195ffa17088",
+                "sha256:8b451d6ead6e3500b6ce5c7916a43d8d8d25ad74b9102a629baccc0808c54971",
+                "sha256:8f06be50669087250f319b706decf69ca71fdecd829091a37cc89398ca4dc17a",
+                "sha256:92a23b0431941a33242b1f0ce6c88a952e09feeea9af4e8be48236a68ffe2205",
+                "sha256:93139acd8109edcdeffd85e3af8ae7d88b258b3a1e13a038f542b79b6d255c54",
+                "sha256:98533fd7fa764e5f85eebe56c8e4094db912ccbe6fbf3a58778d543cadd0db08",
+                "sha256:9f665d1e6474af9f9da5e86c2a3a2d2d6204e04d5af9c06b9d42afa6ebde3f21",
+                "sha256:b059ac2c4c7a97daafa7dc850b43b2d3667def858a4f112d1aa082e5c3d6cf7d",
+                "sha256:b1be1c872b9b5fcc229adeadbeb51422a9633abd847c0ff87dc4ef9bb184ae08",
+                "sha256:b7cf63d2c6928b51d35dfdbda6f2c1fddbe51a6bc4a9d4ee6ea0e11670dd981e",
+                "sha256:bc2e3069569ea9dbe88d6b8ea38f439a6aad8f6e7a6283a38edf61ddefb3a9bf",
+                "sha256:bcf1207e2f2385a576832af02702de104be71301c2696d0012b1b93fe34aaa5b",
+                "sha256:ca26ba5767888c84bf5a0c1a32f069e8204ce8c21d00a49c90dabeba00ce0145",
+                "sha256:cbe68deb8580462ca0d9eb56a81912f59eb4542e1ef8f987405e35a0179f4ea2",
+                "sha256:d6caf3cd38449ec3cd8a68b375e0c6fe4b6fd04edb6c9766b55ef84a6e8ddf2d",
+                "sha256:d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d",
+                "sha256:d889b53ae2f030f756e61a7bff13684dcd77e9af8b10c6048fb2c559d6ed6eaf",
+                "sha256:de596695a75496deb3b499c8c4f8e60376e0516e1a774e7bc046f0f48cd620ad",
+                "sha256:e6a90167bcca1216606223a05e2cf991bb25b14695c518bc65639463d7db722d",
+                "sha256:ed2d9c0704f2dc4fa980b99d565c0c9a543fe5101c25b3d60488b8ba80f0cce1",
+                "sha256:ee7810cf7c83fa227ba9125de6084e5e8b08c59038a7b2c9045ef4dde61663b4",
+                "sha256:f0b4b06da13275bc02adfeb82643c4a6385bd08d26f03068c2796f60d125f6f2",
+                "sha256:f11c9102c56ffb9ca87134bd025a43d2aba3f1155f508eff88f694b33a9c6d19",
+                "sha256:f5bb289bb835f9fe1a1e9300d011eef4d69661bb9b34d5e196e5e82c4cb09b37",
+                "sha256:f6d3d4c905e26354e8f9d82548475c46d8e0889538cb0657aa9c6f0872a37aa4",
+                "sha256:fcb59711009b0168d6ee0bd8fb5eb259c4ab1717b2f538bbf36bacf207ef7a68",
+                "sha256:fd2a5403a75b54661182b75ec6132437a181209b901446ee5724b589af8edef1"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==10.0.1"
+        },
+        "progressbar": {
+            "hashes": [
+                "sha256:5d81cb529da2e223b53962afd6c8ca0f05c6670e40309a7219eacc36af9b6c63"
+            ],
+            "index": "pypi",
+            "version": "==2.5"
+        },
+        "pyarrow": {
+            "hashes": [
+                "sha256:1cbcfcbb0e74b4d94f0b7dde447b835a01bc1d16510edb8bb7d6224b9bf5bafc",
+                "sha256:25aa11c443b934078bfd60ed63e4e2d42461682b5ac10f67275ea21e60e6042c",
+                "sha256:2d53ba72917fdb71e3584ffc23ee4fcc487218f8ff29dd6df3a34c5c48fe8c06",
+                "sha256:2d942c690ff24a08b07cb3df818f542a90e4d359381fbff71b8f2aea5bf58841",
+                "sha256:2f51dc7ca940fdf17893227edb46b6784d37522ce08d21afc56466898cb213b2",
+                "sha256:362a7c881b32dc6b0eccf83411a97acba2774c10edcec715ccaab5ebf3bb0835",
+                "sha256:3e99be85973592051e46412accea31828da324531a060bd4585046a74ba45854",
+                "sha256:40bb42afa1053c35c749befbe72f6429b7b5f45710e85059cdd534553ebcf4f2",
+                "sha256:410624da0708c37e6a27eba321a72f29d277091c8f8d23f72c92bada4092eb5e",
+                "sha256:41a1451dd895c0b2964b83d91019e46f15b5564c7ecd5dcb812dadd3f05acc97",
+                "sha256:5461c57dbdb211a632a48facb9b39bbeb8a7905ec95d768078525283caef5f6d",
+                "sha256:69309be84dcc36422574d19c7d3a30a7ea43804f12552356d1ab2a82a713c418",
+                "sha256:7c28b5f248e08dea3b3e0c828b91945f431f4202f1a9fe84d1012a761324e1ba",
+                "sha256:8f40be0d7381112a398b93c45a7e69f60261e7b0269cc324e9f739ce272f4f70",
+                "sha256:a37bc81f6c9435da3c9c1e767324ac3064ffbe110c4e460660c43e144be4ed85",
+                "sha256:aaee8f79d2a120bf3e032d6d64ad20b3af6f56241b0ffc38d201aebfee879d00",
+                "sha256:ad42bb24fc44c48f74f0d8c72a9af16ba9a01a2ccda5739a517aa860fa7e3d56",
+                "sha256:ad7c53def8dbbc810282ad308cc46a523ec81e653e60a91c609c2233ae407689",
+                "sha256:becc2344be80e5dce4e1b80b7c650d2fc2061b9eb339045035a1baa34d5b8f1c",
+                "sha256:caad867121f182d0d3e1a0d36f197df604655d0b466f1bc9bafa903aa95083e4",
+                "sha256:ccbf29a0dadfcdd97632b4f7cca20a966bb552853ba254e874c66934931b9841",
+                "sha256:da93340fbf6f4e2a62815064383605b7ffa3e9eeb320ec839995b1660d69f89b",
+                "sha256:e217d001e6389b20a6759392a5ec49d670757af80101ee6b5f2c8ff0172e02ca",
+                "sha256:f010ce497ca1b0f17a8243df3048055c0d18dcadbcc70895d5baf8921f753de5",
+                "sha256:f12932e5a6feb5c58192209af1d2607d488cb1d404fbc038ac12ada60327fa34"
+            ],
+            "index": "pypi",
+            "version": "==11.0.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb",
+                "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.1.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b",
+                "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"
+            ],
+            "version": "==2023.3.post1"
+        },
+        "scikit-learn": {
+            "hashes": [
+                "sha256:0c275a06c5190c5ce00af0acbb61c06374087949f643ef32d355ece12c4db043",
+                "sha256:0ce9233cdf0cdcf0858a5849d306490bf6de71fa7603a3835124e386e62f2311",
+                "sha256:0e1aa8f206d0de814b81b41d60c1ce31f7f2c7354597af38fae46d9c47c45122",
+                "sha256:14e8775eba072ab10866a7e0596bc9906873e22c4c370a651223372eb62de180",
+                "sha256:1a231cced3ee3fa04756b4a7ab532dc9417acd581a330adff5f2c01ac2831fcf",
+                "sha256:1ec668ce003a5b3d12d020d2cde0abd64b262ac5f098b5c84cf9657deb9996a8",
+                "sha256:3153612ff8d36fa4e35ef8b897167119213698ea78f3fd130b4068e6f8d2da5a",
+                "sha256:4d379f2b34096105a96bd857b88601dffe7389bd55750f6f29aaa37bc6272eb5",
+                "sha256:52b77cc08bd555969ec5150788ed50276f5ef83abb72e6f469c5b91a0009bbca",
+                "sha256:58b0c2490eff8355dc26e884487bf8edaccf2ba48d09b194fb2f3a026dd64f9d",
+                "sha256:66f7bb1fec37d65f4ef85953e1df5d3c98a0f0141d394dcdaead5a6de9170347",
+                "sha256:6bb9490fdb8e7e00f1354621689187bef3cab289c9b869688f805bf724434755",
+                "sha256:7d8dee8c1f40eeba49a85fe378bdf70a07bb64aba1a08fda1e0f48d27edfc3e6",
+                "sha256:8454d57a22d856f1fbf3091bd86f9ebd4bff89088819886dc0c72f47a6c30652",
+                "sha256:845f81c7ceb4ea6bac64ab1c9f2ce8bef0a84d0f21f3bece2126adcc213dfecd",
+                "sha256:8d993fb70a1d78c9798b8f2f28705bfbfcd546b661f9e2e67aa85f81052b9c53",
+                "sha256:9147a3a4df4d401e618713880be023e36109c85d8569b3bf5377e6cd3fecdeac",
+                "sha256:a15d964d9eb181c79c190d3dbc2fff7338786bf017e9039571418a1d53dab236",
+                "sha256:a683394bc3f80b7c312c27f9b14ebea7766b1f0a34faf1a2e9158d80e860ec26",
+                "sha256:a7135a03af71138669f19bc96e7d0cc8081aed4b3565cc3b131135d65fc642ba",
+                "sha256:c413c2c850241998168bbb3bd1bb59ff03b1195a53864f0b80ab092071af6028",
+                "sha256:c6448c37741145b241eeac617028ba6ec2119e1339b1385c9720dae31367f2be",
+                "sha256:ccbbedae99325628c1d1cbe3916b7ef58a1ce949672d8d39c8b190e10219fd32",
+                "sha256:d2cd3634695ad192bf71645702b3df498bd1e246fc2d529effdb45a06ab028b4",
+                "sha256:ef540e09873e31569bc8b02c8a9f745ee04d8e1263255a15c9969f6f5caa627f",
+                "sha256:f66eddfda9d45dd6cadcd706b65669ce1df84b8549875691b1f403730bdef217"
+            ],
+            "index": "pypi",
+            "version": "==1.3.1"
+        },
+        "scipy": {
+            "hashes": [
+                "sha256:00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3",
+                "sha256:033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929",
+                "sha256:0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7",
+                "sha256:15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0",
+                "sha256:370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0",
+                "sha256:3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1",
+                "sha256:4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2",
+                "sha256:5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e",
+                "sha256:5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a",
+                "sha256:5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221",
+                "sha256:74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280",
+                "sha256:7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88",
+                "sha256:90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6",
+                "sha256:91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d",
+                "sha256:925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165",
+                "sha256:9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3",
+                "sha256:9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917",
+                "sha256:a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83",
+                "sha256:bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc",
+                "sha256:bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd",
+                "sha256:c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156",
+                "sha256:d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6",
+                "sha256:dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15",
+                "sha256:e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc",
+                "sha256:e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820"
+            ],
+            "index": "pypi",
+            "version": "==1.11.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "sympy": {
+            "hashes": [
+                "sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5",
+                "sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.12"
+        },
+        "threadpoolctl": {
+            "hashes": [
+                "sha256:2b7818516e423bdaebb97c723f86a7c6b0a83d3f3b0970328d66f4d9104dc032",
+                "sha256:c96a0ba3bdddeaca37dc4cc7344aafad41cdb8c313f74fdfe387a867bba93355"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.2.0"
+        },
+        "torch": {
+            "hashes": [
+                "sha256:0882243755ff28895e8e6dc6bc26ebcf5aa0911ed81b2a12f241fc4b09075b13",
+                "sha256:1adb60d369f2650cac8e9a95b1d5758e25d526a34808f7448d0bd599e4ae9072",
+                "sha256:1bcffc16b89e296826b33b98db5166f990e3b72654a2b90673e817b16c50e32b",
+                "sha256:25aa43ca80dcdf32f13da04c503ec7afdf8e77e3a0183dd85cd3e53b2842e527",
+                "sha256:359bfaad94d1cda02ab775dc1cc386d585712329bb47b8741607ef6ef4950747",
+                "sha256:423e0ae257b756bb45a4b49072046772d1ad0c592265c5080070e0767da4e490",
+                "sha256:567f84d657edc5582d716900543e6e62353dbe275e61cdc36eda4929e46df9e7",
+                "sha256:5ef3ea3d25441d3957348f7e99c7824d33798258a2bf5f0f0277cbcadad2e20d",
+                "sha256:671a2565e3f63b8fe8e42ae3e36ad249fe5e567435ea27b94edaa672a7d0c416",
+                "sha256:787b5a78aa7917465e9b96399b883920c88a08f4eb63b5a5d2d1a16e27d2f89b",
+                "sha256:7c84e44d9002182edd859f3400deaa7410f5ec948a519cc7ef512c2f9b34d2c4",
+                "sha256:8742bdc62946c93f75ff92da00e3803216c6cce9b132fbca69664ca38cfb3e18",
+                "sha256:8ced00b3ba471856b993822508f77c98f48a458623596a4c43136158781e306a",
+                "sha256:b6019b1de4978e96daa21d6a3ebb41e88a0b474898fe251fd96189587408873e",
+                "sha256:c62df99352bd6ee5a5a8d1832452110435d178b5164de450831a3a8cc14dc680",
+                "sha256:dbd68cbd1cd9da32fe5d294dd3411509b3d841baecb780b38b3b7b06c7754434",
+                "sha256:e10e1597f2175365285db1b24019eb6f04d53dcd626c735fc502f1e8b6be9875",
+                "sha256:e617b1d0abaf6ced02dbb9486803abfef0d581609b09641b34fa315c9c40766d",
+                "sha256:ef654427d91600129864644e35deea761fb1fe131710180b952a6f2e2207075e",
+                "sha256:f66aa6b9580a22b04d0af54fcd042f52406a8479e2b6a550e3d9f95963e168c8"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.8.0"
+        },
+        "tzdata": {
+            "hashes": [
+                "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a",
+                "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"
+            ],
+            "markers": "python_version >= '2'",
+            "version": "==2023.3"
+        }
+    },
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8",
+                "sha256:f2510e7fdcd6cfda4ec50014726d4857abf79acfc010084ce8c26091913f1b25"
+            ],
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==3.0.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f",
+                "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7",
+                "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100",
+                "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573",
+                "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d",
+                "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f",
+                "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9",
+                "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300",
+                "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948",
+                "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325",
+                "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9",
+                "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71",
+                "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186",
+                "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f",
+                "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe",
+                "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855",
+                "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80",
+                "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393",
+                "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c",
+                "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204",
+                "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377",
+                "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"
+            ],
+            "index": "pypi",
+            "version": "==23.9.1"
+        },
+        "click": {
+            "hashes": [
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.7"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e",
+                "sha256:cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==0.3.7"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
+                "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
+            ],
+            "index": "pypi",
+            "version": "==5.12.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
+                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20",
+                "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.11.2"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3",
+                "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.11.0"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:21da8ed1294f88d66c82eb3e624a0993291613548bb17fbccaa220c31c41293b",
+                "sha256:d22816c963816d7810b87afe0bdf5c80009e1078ecbb9c8f2e2a24d4430039b1"
+            ],
+            "index": "pypi",
+            "version": "==3.0.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:38e1ff8edb991273ec9f6181244a6a391ac30e9f5098e7535640ea6be97a7c86",
+                "sha256:712cbd236609acc6a3e2e97253dfc52d4c2082982a88f61b640ecf0817eab899"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.12.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
+                "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.8.0"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## What is Pysurvival ?
 PySurvival is an open source python package for Survival Analysis modeling - *the modeling concept used to analyze or predict when an event is likely to happen*. It is built upon the most commonly used machine learning packages such [NumPy](http://www.numpy.org/), [SciPy](https://www.scipy.org/) and [PyTorch](https://pytorch.org/).
 
-PySurvival is compatible with Python 2.7-3.7.
+PySurvival is compatible with Python 2.7-3.10.
 
 Check out the documentation [here](https://www.pysurvival.io)
 

--- a/pysurvival/__init__.py
+++ b/pysurvival/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
-import sys
-import torch
 
+import sys
+
+import torch
 
 # -------------------------------- VERSION --------------------------------- #
 # PEP0440 compatible formatted version, see:
@@ -20,7 +21,7 @@ import torch
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.1.2'
+__version__ = "0.1.2"
 
 
 # ---------------------------- GLOBAL VARIABLES ---------------------------- #
@@ -28,5 +29,7 @@ PYTHON_VERSION = sys.version_info[0]
 HAS_GPU = torch.cuda.is_available()
 
 
-__all__ = [  'PYTHON_VERSION', 'HAS_GPU', ]
-
+__all__ = [
+    "PYTHON_VERSION",
+    "HAS_GPU",
+]

--- a/pysurvival/__init__.py
+++ b/pysurvival/__init__.py
@@ -21,7 +21,7 @@ import torch
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "0.1.2"
+__version__ = "0.1.0"
 
 
 # ---------------------------- GLOBAL VARIABLES ---------------------------- #

--- a/pysurvival/cpp_extensions/_coxph.pyx
+++ b/pysurvival/cpp_extensions/_coxph.pyx
@@ -4,17 +4,20 @@
 # Importing Numpy
 #-----------------
 import numpy as np
+
 cimport numpy as cnp
 
 # Importing cython and C++ 
 #---------------------------
+
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-from libcpp.pair cimport pair
-from libcpp.map cimport map
+
 from libcpp cimport bool
 from libcpp.algorithm cimport sort
+from libcpp.map cimport map
+from libcpp.pair cimport pair
+from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 
 # Importing C++ specific functions

--- a/pysurvival/cpp_extensions/_functions.pyx
+++ b/pysurvival/cpp_extensions/_functions.pyx
@@ -4,12 +4,13 @@
 # Importing cython and C++ 
 #---------------------------
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-from libcpp.pair cimport pair
-from libcpp.map cimport map
-from libcpp.set cimport set
+
 from libcpp cimport bool
+from libcpp.map cimport map
+from libcpp.pair cimport pair
+from libcpp.set cimport set
+from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 
 # Importing C++ objects from functions.h

--- a/pysurvival/cpp_extensions/_metrics.pyx
+++ b/pysurvival/cpp_extensions/_metrics.pyx
@@ -4,12 +4,13 @@
 # Importing cython and C++ 
 #---------------------------
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-from libcpp.pair cimport pair
-from libcpp.map cimport map
-from libcpp.set cimport set
+
 from libcpp cimport bool
+from libcpp.map cimport map
+from libcpp.pair cimport pair
+from libcpp.set cimport set
+from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 
 # Importing C++ functions from metrics.h

--- a/pysurvival/cpp_extensions/_non_parametric.pyx
+++ b/pysurvival/cpp_extensions/_non_parametric.pyx
@@ -4,12 +4,13 @@
 # Importing cython and C++ 
 #---------------------------
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-from libcpp.pair cimport pair
-from libcpp.map cimport map
-from libcpp.set cimport set
+
 from libcpp cimport bool
+from libcpp.map cimport map
+from libcpp.pair cimport pair
+from libcpp.set cimport set
+from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 
 # Importing C++ object KaplanMeierModel from non_parametric.h

--- a/pysurvival/cpp_extensions/_survival_forest.cpp
+++ b/pysurvival/cpp_extensions/_survival_forest.cpp
@@ -6345,9 +6345,9 @@ static void __pyx_tp_dealloc_10pysurvival_6models_16_survival_forest__SurvivalFo
   {
     PyObject *etype, *eval, *etb;
     PyErr_Fetch(&etype, &eval, &etb);
-    ++Py_REFCNT(o);
+    Py_SET_REFCNT(o, Py_REFCNT(o) + 1);
     __pyx_pw_10pysurvival_6models_16_survival_forest_20_SurvivalForestModel_3__dealloc__(o);
-    --Py_REFCNT(o);
+    Py_SET_REFCNT(o, Py_REFCNT(o) - 1);
     PyErr_Restore(etype, eval, etb);
   }
   (*Py_TYPE(o)->tp_free)(o);
@@ -6820,7 +6820,7 @@ static int __Pyx_modinit_type_init_code(void) {
   __pyx_vtable_10pysurvival_6models_16_survival_forest__SurvivalForestModel.predict_hazard = (std::vector<std::vector<double> >  (*)(struct __pyx_obj_10pysurvival_6models_16_survival_forest__SurvivalForestModel *, std::vector<std::vector<double> > , int __pyx_skip_dispatch, struct __pyx_opt_args_10pysurvival_6models_16_survival_forest_20_SurvivalForestModel_predict_hazard *__pyx_optional_args))__pyx_f_10pysurvival_6models_16_survival_forest_20_SurvivalForestModel_predict_hazard;
   __pyx_vtable_10pysurvival_6models_16_survival_forest__SurvivalForestModel.predict_risk = (std::vector<double>  (*)(struct __pyx_obj_10pysurvival_6models_16_survival_forest__SurvivalForestModel *, std::vector<std::vector<double> > , int __pyx_skip_dispatch, struct __pyx_opt_args_10pysurvival_6models_16_survival_forest_20_SurvivalForestModel_predict_risk *__pyx_optional_args))__pyx_f_10pysurvival_6models_16_survival_forest_20_SurvivalForestModel_predict_risk;
   if (PyType_Ready(&__pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel) < 0) __PYX_ERR(1, 57, __pyx_L1_error)
-  __pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel.tp_print = 0;
+  __pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel.tp_repr = 0;
   if ((CYTHON_USE_TYPE_SLOTS && CYTHON_USE_PYTYPE_LOOKUP) && likely(!__pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel.tp_dictoffset && __pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel.tp_getattro == PyObject_GenericGetAttr)) {
     __pyx_type_10pysurvival_6models_16_survival_forest__SurvivalForestModel.tp_getattro = __Pyx_PyObject_GenericGetAttr;
   }

--- a/pysurvival/cpp_extensions/_survival_forest.pyx
+++ b/pysurvival/cpp_extensions/_survival_forest.pyx
@@ -4,13 +4,15 @@
 # Importing cython and C++ 
 #---------------------------
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-from libcpp.pair cimport pair
-from libcpp.map cimport map
-from libcpp.set cimport set
-from libcpp cimport bool
+
 from libc.stdint cimport uint32_t as uint
+from libcpp cimport bool
+from libcpp.map cimport map
+from libcpp.pair cimport pair
+from libcpp.set cimport set
+from libcpp.string cimport string
+from libcpp.vector cimport vector
+
 
 # Importing C++ object SurvivalForestModel from SurvivalForestModel.h
 #-----------------------------------------------------------

--- a/pysurvival/cpp_extensions/_svm.pyx
+++ b/pysurvival/cpp_extensions/_svm.pyx
@@ -4,17 +4,21 @@
 # Importing Numpy
 #-----------------
 import numpy as np
+
 cimport numpy as cnp
 
 # Importing cython and C++ 
 #---------------------------
+
 import cython
-from libcpp.vector cimport vector
-from libcpp.string cimport string
+
+from libc.stdlib cimport RAND_MAX, rand, srand
+from libcpp cimport bool
 from libcpp.map cimport map
 from libcpp.set cimport set
-from libcpp cimport bool
-from libc.stdlib cimport rand, srand, RAND_MAX
+from libcpp.string cimport string
+from libcpp.vector cimport vector
+
 
 # Importing math functions
 #--------------------------

--- a/pysurvival/datasets/__init__.py
+++ b/pysurvival/datasets/__init__.py
@@ -1,92 +1,89 @@
 from __future__ import absolute_import
+
+import os
+
 import numpy as np
 import pandas as pd
-import os 
 from sklearn.model_selection import train_test_split
 
 try:
-	CURRENT_FOLDER = os.path.dirname(os.path.realpath(__file__)) + '/'
+    CURRENT_FOLDER = os.path.dirname(os.path.realpath(__file__)) + "/"
 except:
-	CURRENT_FOLDER = os.path.dirname(os.path.realpath('__file__')) + '/'
+    CURRENT_FOLDER = os.path.dirname(os.path.realpath("__file__")) + "/"
 
 
 class Dataset(object):
-	""" Helper object built to read/load tutorial datasets with ease."""
+    """Helper object built to read/load tutorial datasets with ease."""
 
-	def __init__(self, name):
+    def __init__(self, name):
+        if "maintenance" in name.lower():
+            self.name = "maintenance"
+            self.time_column = "lifetime"
+            self.event_column = "broken"
+            self.filename = CURRENT_FOLDER + "maintenance.csv"
 
-		if 'maintenance' in name.lower() :
-			self.name = 'maintenance'
-			self.time_column = 'lifetime'
-			self.event_column = 'broken'
-			self.filename = CURRENT_FOLDER +'maintenance.csv'
+        elif "simple" in name.lower() or "example" in name.lower():
+            self.name = "simple_example"
+            self.time_column = "time"
+            self.event_column = "event"
+            self.filename = CURRENT_FOLDER + "simple_example.csv"
 
-		elif 'simple' in name.lower() or 'example' in name.lower()  :
-			self.name = 'simple_example'
-			self.time_column = 'time'
-			self.event_column = 'event'
-			self.filename = CURRENT_FOLDER +'simple_example.csv'
+        elif "credit" in name.lower():
+            self.name = "credit_risk"
+            self.time_column = "duration"
+            self.event_column = "full_repaid"
+            self.filename = CURRENT_FOLDER + "credit_risk.csv"
 
-		elif 'credit' in name.lower() :
-			self.name = 'credit_risk'
-			self.time_column = 'duration'
-			self.event_column = 'full_repaid'
-			self.filename = CURRENT_FOLDER +'credit_risk.csv'
+        elif "employee" in name.lower():
+            self.name = "employee_attrition"
+            self.time_column = "time_spend_company"
+            self.event_column = "left"
+            self.filename = CURRENT_FOLDER + "employee_attrition.csv"
 
-		elif 'employee' in name.lower() :
-			self.name = 'employee_attrition'
-			self.time_column = 'time_spend_company'
-			self.event_column = 'left'
-			self.filename = CURRENT_FOLDER +'employee_attrition.csv'
+        elif "churn" in name.lower():
+            self.name = "churn"
+            self.time_column = "months_active"
+            self.event_column = "churn"
+            self.filename = CURRENT_FOLDER + "churn.csv"
 
-		elif 'churn' in name.lower() :
-			self.name = 'churn'
-			self.time_column = 'months_active'
-			self.event_column = 'churn'
-			self.filename = CURRENT_FOLDER +'churn.csv'
+    def load(self):
+        """Loading the dataset"""
 
+        if "maintenance" in self.filename.lower():
+            sep = ";"
+        else:
+            sep = ","
 
-	def load(self):
-		""" Loading the dataset """
+        data = pd.read_csv(self.filename, sep=sep)
+        return data
 
-		if 'maintenance' in self.filename.lower():
-			sep = ";"
-		else:
-			sep = ","
+    def load_train_test(self, test_size=0.3):
+        """Loading the dataset and returning X, T, E split between
+        training and testing
+        """
 
-		data = pd.read_csv(self.filename, sep=sep)
-		return data
+        # Reading the dataset
+        data = self.load()
+        N = data.shape[0]
 
+        # Extracting the features
+        columns_to_exclude = [self.time_column, self.event_column]
+        self.features = np.setdiff1d(data.columns, columns_to_exclude).tolist()
+        features = self.features
+        time = self.time_column
+        event = self.event_column
 
-	def load_train_test(self, test_size = 0.3):
-		""" Loading the dataset and returning X, T, E split between 
-			training and testing 
-		"""
+        # Building training and testing sets #
+        index_train, index_test = train_test_split(range(N), test_size=test_size)
+        data_train = data.loc[index_train].reset_index(drop=True)
+        data_test = data.loc[index_test].reset_index(drop=True)
 
-		# Reading the dataset
-		data = self.load()
-		N = data.shape[0]
+        # Creating the X, T and E input
+        X_train, X_test = data_train[features], data_test[features]
+        T_train, T_test = data_train[time].values, data_test[time].values
+        E_train, E_test = data_train[event].values, data_test[event].values
 
-		# Extracting the features
-		columns_to_exclude = [self.time_column, self.event_column]
-		self.features = np.setdiff1d(data.columns, columns_to_exclude).tolist()
-		features = self.features
-		time = self.time_column
-		event = self.event_column
+        return X_train, T_train, E_train, X_test, T_test, E_test
 
-		# Building training and testing sets #
-		index_train, index_test = train_test_split( range(N), 
-			test_size = test_size)
-		data_train = data.loc[index_train].reset_index( drop = True )
-		data_test  = data.loc[index_test].reset_index( drop = True )
-
-		# Creating the X, T and E input
-		X_train, X_test = data_train[features], data_test[features]
-		T_train, T_test = data_train[time].values, data_test[time].values
-		E_train, E_test = data_train[event].values, data_test[event].values
-
-		return X_train, T_train, E_train, X_test, T_test, E_test
-
-
-	def __repr__(self):
-		return self.name
+    def __repr__(self):
+        return self.name

--- a/pysurvival/models/__init__.py
+++ b/pysurvival/models/__init__.py
@@ -1,100 +1,100 @@
 from __future__ import absolute_import
+
 import copy
-import tempfile
-import pyarrow as pa
 import os
-import torch
+import tempfile
 import zipfile
+
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import torch
 from sklearn.preprocessing import StandardScaler
+
 from pysurvival import utils
 from pysurvival.utils._functions import _get_time_buckets
 
 
 class BaseModel(object):
-    """ Base class for all estimators in pysurvival. It should not be used on
-        its own.
+    """Base class for all estimators in pysurvival. It should not be used on
+    its own.
     """
 
     def __init__(self, auto_scaler=True):
-        
         # Creating a scikit-learner scaler
         self.auto_scaler = auto_scaler
         if self.auto_scaler:
             self.scaler = StandardScaler()
         else:
             self.scaler = None
-        
+
         # Creating a place holder for the time axis
-        self.times = [0.]
+        self.times = [0.0]
 
         # Creating the model's name
         self.__repr__()
 
-
     def __repr__(self):
-        """ Creates the representation of the Object """
+        """Creates the representation of the Object"""
 
         self.name = self.__class__.__name__
         return self.name
 
-
     def save(self, path_file):
-        """ Save the model components: 
-                * the paremeters of the model (parameters) 
-                * the PyTorch model itself (model) if it exists
-            And Compress them into a zip file
+        """Save the model components:
+            * the paremeters of the model (parameters)
+            * the PyTorch model itself (model) if it exists
+        And Compress them into a zip file
 
-            Parameters
-            ----------
-            * path_file, str
-                address of the file where the model will be saved
-        """ 
+        Parameters
+        ----------
+        * path_file, str
+            address of the file where the model will be saved
+        """
 
         # Ensuring the file has the proper name
-        folder_name = os.path.dirname(path_file) + '/'
+        folder_name = os.path.dirname(path_file) + "/"
         file_name = os.path.basename(path_file)
-        if not file_name.endswith('.zip'):
-            file_name += '.zip'
+        if not file_name.endswith(".zip"):
+            file_name += ".zip"
 
         # Checking if the folder is accessible
         if not os.access(folder_name, os.W_OK):
-            error_msg = '{} is not an accessible directory.'.format(folder_name)
+            error_msg = "{} is not an accessible directory.".format(folder_name)
             raise OSError(error_msg)
 
         # Saving all the elements to save
         elements_to_save = []
 
         # Changing the format of scaler parameters if exist
-        temp_scaler = copy.deepcopy(self.__dict__.get('scaler'))
+        temp_scaler = copy.deepcopy(self.__dict__.get("scaler"))
         if temp_scaler is not None:
-            self.__dict__['scaler'] = temp_scaler.__dict__
+            self.__dict__["scaler"] = temp_scaler.__dict__
 
         # Saving the model parameters
         parameters_to_save = {}
-        for k in self.__dict__ :
-            if k != 'model' :
+        for k in self.__dict__:
+            if k != "model":
                 parameters_to_save[k] = self.__dict__[k]
 
         # Serializing the parameters
-        elements_to_save.append('parameters')
-        with open('parameters' , 'wb') as f:
+        elements_to_save.append("parameters")
+        with open("parameters", "wb") as f:
             serialized_to_save = pa.serialize(parameters_to_save)
             f.write(serialized_to_save.to_buffer())
-            
+
         # Saving the torch model if exists
-        if 'model' in self.__dict__.keys():
-            elements_to_save.append('model')
-            torch.save(self.model, 'model') 
-            
+        if "model" in self.__dict__.keys():
+            elements_to_save.append("model")
+            torch.save(self.model, "model")
+
         # Compressing the elements to save in zip
         full_path = folder_name + file_name
-        print('Saving the model to disk as {}'.format(full_path))
-        with zipfile.ZipFile(full_path, 'w') as myzip:
-            for f in elements_to_save:   
+        print("Saving the model to disk as {}".format(full_path))
+        with zipfile.ZipFile(full_path, "w") as myzip:
+            for f in elements_to_save:
                 myzip.write(f)
-                
+
         # Erasing temp files
         for temp_file in elements_to_save:
             os.remove(temp_file)
@@ -102,220 +102,212 @@ class BaseModel(object):
         # Restore the scaler
         if temp_scaler is not None:
             self.scaler = StandardScaler()
-            self.__dict__['scaler'] = copy.deepcopy(temp_scaler)
-
+            self.__dict__["scaler"] = copy.deepcopy(temp_scaler)
 
     def load(self, path_file):
-        """ Load the model components from a .zip file: 
-                * the parameters of the model (.params) 
-                * the PyTorch model itself (.model) is exists
+        """Load the model components from a .zip file:
+            * the parameters of the model (.params)
+            * the PyTorch model itself (.model) is exists
 
-            Parameters
-            ----------
-            * path_file, str
-                address of the file where the model will be loaded from 
-        """        
+        Parameters
+        ----------
+        * path_file, str
+            address of the file where the model will be loaded from
+        """
 
         # Ensuring the file has the proper name
-        folder_name = os.path.dirname(path_file) + '/'
+        folder_name = os.path.dirname(path_file) + "/"
         file_name = os.path.basename(path_file)
-        if not file_name.endswith('.zip'):
-            file_name += '.zip'
+        if not file_name.endswith(".zip"):
+            file_name += ".zip"
 
-        # Opening the '.zip' file 
+        # Opening the '.zip' file
         full_path = folder_name + file_name
-        print('Loading the model from {}'.format(full_path))
+        print("Loading the model from {}".format(full_path))
 
         # Creating temp folder
-        temp_folder = tempfile.mkdtemp() + '/'
-            
+        temp_folder = tempfile.mkdtemp() + "/"
+
         # Unzip files in temp folder
-        with zipfile.ZipFile(path_file, 'r') as zip_ref:
+        with zipfile.ZipFile(path_file, "r") as zip_ref:
             zip_ref.extractall(temp_folder)
-            input_zip=zipfile.ZipFile(path_file)
+            input_zip = zipfile.ZipFile(path_file)
 
         # Loading the files
         elements_to_load = []
         for file_name in input_zip.namelist():
-
             # Loading the parameters
-            if 'parameters' in file_name.lower():
-                content = input_zip.read( 'parameters' )
+            if "parameters" in file_name.lower():
+                content = input_zip.read("parameters")
                 self.__dict__ = copy.deepcopy(pa.deserialize(content))
-                elements_to_load.append(temp_folder +'parameters')
+                elements_to_load.append(temp_folder + "parameters")
 
                 # If a scaler was available then load it too
-                temp_scaler = copy.deepcopy(self.__dict__.get('scaler'))
+                temp_scaler = copy.deepcopy(self.__dict__.get("scaler"))
                 if temp_scaler is not None:
                     self.scaler = StandardScaler()
                     self.scaler.__dict__ = temp_scaler
 
             # Loading the PyTorch model
-            if 'model' in file_name.lower():
-                model = torch.load( temp_folder + 'model' )
+            if "model" in file_name.lower():
+                model = torch.load(temp_folder + "model")
                 self.model = model
-                elements_to_load.append(temp_folder +'model')
+                elements_to_load.append(temp_folder + "model")
 
         # Erasing temp files
         for temp_file in elements_to_load:
             os.remove(temp_file)
 
-
     def get_time_buckets(self, extra_timepoint=False):
-        """ Creating the time buckets based on the times axis such that
-            for the k-th time bin is [ t(k-1), t(k) ] in the time axis.
+        """Creating the time buckets based on the times axis such that
+        for the k-th time bin is [ t(k-1), t(k) ] in the time axis.
         """
-        
+
         # Checking if the time axis has already been created
         if self.times is None or len(self.times) <= 1:
-            error = 'The time axis needs to be created before'
-            error += ' using the method get_time_buckets.'
+            error = "The time axis needs to be created before"
+            error += " using the method get_time_buckets."
             raise AttributeError(error)
-        
+
         # Creating the base time buckets
         time_buckets = _get_time_buckets(self.times)
-        
+
         # Adding an additional element if specified
         if extra_timepoint:
-            time_buckets += [ (time_buckets[-1][1], time_buckets[-1][1]*1.01) ]
+            time_buckets += [(time_buckets[-1][1], time_buckets[-1][1] * 1.01)]
         self.time_buckets = time_buckets
 
+    def predict_hazard(self, x, t=None, **kwargs):
+        """Predicts the hazard function h(t, x)
 
-    def predict_hazard(self, x, t = None, **kwargs):
-        """ Predicts the hazard function h(t, x)
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        * `t`: **double** *(default=None)* --
+             time at which the prediction should be performed.
+             If None, then return the function for all available t.
 
-            * `t`: **double** *(default=None)* --
-                 time at which the prediction should be performed. 
-                 If None, then return the function for all available t.
-
-            Returns
-            -------
-            * `hazard`: **numpy.ndarray** --
-                array-like representing the prediction of the hazard function
+        Returns
+        -------
+        * `hazard`: **numpy.ndarray** --
+            array-like representing the prediction of the hazard function
         """
 
         # Checking if the data has the right format
         x = utils.check_data(x)
 
         # Calculating hazard, density, survival
-        hazard, density, survival = self.predict( x, t, **kwargs)
+        hazard, density, survival = self.predict(x, t, **kwargs)
 
         return hazard
 
+    def predict_density(self, x, t=None, **kwargs):
+        """Predicts the density function d(t, x)
 
-    def predict_density(self, x, t = None, **kwargs):
-        """ Predicts the density function d(t, x)
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        * `t`: **double** *(default=None)* --
+             time at which the prediction should be performed.
+             If None, then return the function for all available t.
 
-            * `t`: **double** *(default=None)* --
-                 time at which the prediction should be performed. 
-                 If None, then return the function for all available t.
-
-            Returns
-            -------
-            * `density`: **numpy.ndarray** --
-                array-like representing the prediction of density function
-        """        
+        Returns
+        -------
+        * `density`: **numpy.ndarray** --
+            array-like representing the prediction of density function
+        """
 
         # Checking if the data has the right format
         x = utils.check_data(x)
 
         # Calculating hazard, density, survival
-        hazard, density, survival = self.predict( x, t, **kwargs )
+        hazard, density, survival = self.predict(x, t, **kwargs)
         return density
 
+    def predict_survival(self, x, t=None, **kwargs):
+        """Predicts the survival function S(t, x)
 
-    def predict_survival(self, x, t = None, **kwargs):
-        """ Predicts the survival function S(t, x)
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        * `t`: **double** *(default=None)* --
+            time at which the prediction should be performed.
+            If None, then return the function for all available t.
 
-            * `t`: **double** *(default=None)* --
-                time at which the prediction should be performed. 
-                If None, then return the function for all available t.
-
-            Returns
-            -------
-            * `survival`: **numpy.ndarray** --
-                array-like representing the prediction of the survival function
-        """        
+        Returns
+        -------
+        * `survival`: **numpy.ndarray** --
+            array-like representing the prediction of the survival function
+        """
 
         # Checking if the data has the right format
         x = utils.check_data(x)
 
         # Calculating hazard, density, survival
-        hazard, density, survival = self.predict( x, t, **kwargs)
+        hazard, density, survival = self.predict(x, t, **kwargs)
         return survival
 
+    def predict_cdf(self, x, t=None, **kwargs):
+        """Predicts the cumulative density function F(t, x)
 
-    def predict_cdf(self, x, t = None, **kwargs):
-        """ Predicts the cumulative density function F(t, x)
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        * `t`: **double** *(default=None)* --
+            time at which the prediction should be performed.
+            If None, then return the function for all available t.
 
-            * `t`: **double** *(default=None)* --
-                time at which the prediction should be performed. 
-                If None, then return the function for all available t.
-
-            Returns
-            -------
-            * `cdf`: **numpy.ndarray** --
-                array-like representing the prediction of the cumulative 
-                density function 
-        """        
+        Returns
+        -------
+        * `cdf`: **numpy.ndarray** --
+            array-like representing the prediction of the cumulative
+            density function
+        """
 
         # Checking if the data has the right format
         x = utils.check_data(x)
 
         # Calculating survival and cdf
         survival = self.predict_survival(x, t, **kwargs)
-        cdf = 1. - survival
+        cdf = 1.0 - survival
         return cdf
 
+    def predict_cumulative_hazard(self, x, t=None, **kwargs):
+        """Predicts the cumulative hazard function H(t, x)
 
-    def predict_cumulative_hazard(self, x, t = None, **kwargs):
-        """ Predicts the cumulative hazard function H(t, x)
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        * `t`: **double** *(default=None)* --
+            time at which the prediction should be performed.
+            If None, then return the function for all available t.
 
-            * `t`: **double** *(default=None)* --
-                time at which the prediction should be performed. 
-                If None, then return the function for all available t.
-
-            Returns
-            -------
-            * `cumulative_hazard`: **numpy.ndarray** --
-                array-like representing the prediction of the cumulative_hazard
-                function
-        """        
+        Returns
+        -------
+        * `cumulative_hazard`: **numpy.ndarray** --
+            array-like representing the prediction of the cumulative_hazard
+            function
+        """
 
         # Checking if the data has the right format
         x = utils.check_data(x)
@@ -325,25 +317,24 @@ class BaseModel(object):
         cumulative_hazard = np.cumsum(hazard, 1)
         return cumulative_hazard
 
-
     def predict_risk(self, x, **kwargs):
-        """ Predicts the Risk Score/Mortality function for all t,
-            R(x) = sum( cumsum(hazard(t, x)) )
-            According to Random survival forests from Ishwaran H et al
-            https://arxiv.org/pdf/0811.1645.pdf
+        """Predicts the Risk Score/Mortality function for all t,
+        R(x) = sum( cumsum(hazard(t, x)) )
+        According to Random survival forests from Ishwaran H et al
+        https://arxiv.org/pdf/0811.1645.pdf
 
-            Parameters
-            ----------
-            * `x` : **array-like** *shape=(n_samples, n_features)* --
-                array-like representing the datapoints. 
-                x should not be standardized before, the model
-                will take care of it
+        Parameters
+        ----------
+        * `x` : **array-like** *shape=(n_samples, n_features)* --
+            array-like representing the datapoints.
+            x should not be standardized before, the model
+            will take care of it
 
-            Returns
-            -------
-            * `risk_score`: **numpy.ndarray** --
-                array-like representing the prediction of Risk Score function
-        """        
+        Returns
+        -------
+        * `risk_score`: **numpy.ndarray** --
+            array-like representing the prediction of Risk Score function
+        """
 
         # Checking if the data has the right format
         x = utils.check_data(x)

--- a/pysurvival/models/multi_task.py
+++ b/pysurvival/models/multi_task.py
@@ -1,43 +1,44 @@
 from __future__ import absolute_import
-import torch 
+
 import numpy as np
-import copy
-import multiprocessing
-from pysurvival import HAS_GPU
+import torch
+
 from pysurvival import utils
+from pysurvival.models import BaseModel
 from pysurvival.utils import neural_networks as nn
 from pysurvival.utils import optimization as opt
-from pysurvival.models import BaseModel
+
 # %matplotlib inline
 
+
 class BaseMultiTaskModel(BaseModel):
-    """ Base class for all  Multi-Task estimators:
+    """Base class for all  Multi-Task estimators:
         * Multi-Task Logistic Regression model (MTLR)
         * Neural Multi-Task Logistic Regression model (N-MTLR)
-    BaseMultiTaskModel shouldn't be used as is. 
+    BaseMultiTaskModel shouldn't be used as is.
     The underlying model is written in PyTorch.
 
     The original Multi-Task model, a.k.a the Multi-Task Logistic Regression
-    model (MTLR), was first introduced by  Chun-Nam Yu et al. in 
-    *Learning Patient-Specific Cancer Survival Distributions as a Sequence of 
+    model (MTLR), was first introduced by  Chun-Nam Yu et al. in
+    *Learning Patient-Specific Cancer Survival Distributions as a Sequence of
     Dependent Regressors*
 
-    The Neural Multi-Task Logistic Regression model (N-MTLR) was developed 
-    by S. Fotso in the paper *Deep Neural Networks for Survival 
-    Analysis Based on a Multi-Task Framework*, allowing the use of 
+    The Neural Multi-Task Logistic Regression model (N-MTLR) was developed
+    by S. Fotso in the paper *Deep Neural Networks for Survival
+    Analysis Based on a Multi-Task Framework*, allowing the use of
     Neural Networks within the original design.
 
     Parameters
     ----------
-    * `structure`:  **list of dictionaries** -- 
+    * `structure`:  **list of dictionaries** --
         Provides the structure of the MLP built within the N-MTLR.
-        
+
         ex: `structure = [ {'activation': 'ReLU', 'num_units': 128}, ]`.
 
         Each dictionary corresponds to a fully connected hidden layer:
 
         * `num_units` is the number of hidden units in this layer
-        * `activation` is the activation function that will be used. 
+        * `activation` is the activation function that will be used.
         The list of all available activation functions can be found :
             * Atan
             * BentIdentity
@@ -62,22 +63,21 @@ class BaseMultiTaskModel(BaseModel):
             * Softsign
             * Swish
             * Tanh
-    
-        In case there are more than one dictionary, 
-        each hidden layer will be applied in the resulting MLP, 
+
+        In case there are more than one dictionary,
+        each hidden layer will be applied in the resulting MLP,
         using the order it is provided in the structure:
-        ex: structure = [ {'activation': 'relu', 'num_units': 128}, 
-                          {'activation': 'tanh', 'num_units': 128}, ] 
+        ex: structure = [ {'activation': 'relu', 'num_units': 128},
+                          {'activation': 'tanh', 'num_units': 128}, ]
 
-    * `bins`: **int** *(default=100)* -- 
-         Number of subdivisions of the time axis 
+    * `bins`: **int** *(default=100)* --
+         Number of subdivisions of the time axis
 
-    * `auto_scaler`: **boolean** *(default=True)* -- 
+    * `auto_scaler`: **boolean** *(default=True)* --
         Determines whether a sklearn scaler should be automatically applied
     """
 
-    def __init__(self, structure, bins = 100, auto_scaler=True):
-
+    def __init__(self, structure, bins=100, auto_scaler=True):
         # Saving the attributes
         self.loss_values = []
         self.bins = bins
@@ -85,64 +85,62 @@ class BaseMultiTaskModel(BaseModel):
 
         # Initializing the elements from BaseModel
         super(BaseMultiTaskModel, self).__init__(auto_scaler)
-        
-        
-    def get_times(self, T, is_min_time_zero = True, extra_pct_time = 0.1):
-        """ Building the time axis (self.times) as well as the time intervals 
-            ( all the [ t(k-1), t(k) ) in the time axis.
+
+    def get_times(self, T, is_min_time_zero=True, extra_pct_time=0.1):
+        """Building the time axis (self.times) as well as the time intervals
+        ( all the [ t(k-1), t(k) ) in the time axis.
         """
 
         # Setting the min_time and max_time
         max_time = max(T)
-        if is_min_time_zero :
-            min_time = 0. 
+        if is_min_time_zero:
+            min_time = 0.0
         else:
             min_time = min(T)
-        
+
         # Setting optional extra percentage time
-        if 0. <= extra_pct_time <= 1.:
+        if 0.0 <= extra_pct_time <= 1.0:
             p = extra_pct_time
         else:
-            raise Exception("extra_pct_time has to be between [0, 1].") 
+            raise Exception("extra_pct_time has to be between [0, 1].")
 
         # Building time points and time buckets
-        self.times = np.linspace(min_time, max_time*(1. + p), self.bins)
+        self.times = np.linspace(min_time, max_time * (1.0 + p), self.bins)
         self.get_time_buckets()
         self.num_times = len(self.time_buckets)
 
-
     def compute_XY(self, X, T, E, is_min_time_zero, extra_pct_time):
-        """ Given the survival_times, events and time_points vectors, 
-            it returns a ndarray of the encodings for all units 
-            such that:
-                Y = [[0, 0, 1, 0, 0],  # unit experienced an event at t = 3
-                     [0, 1, 0, 0, 0],  # unit experienced an event at t = 2
-                     [0, 1, 1, 1, 1],] # unit was censored at t = 2
-        """ 
+        """Given the survival_times, events and time_points vectors,
+        it returns a ndarray of the encodings for all units
+        such that:
+            Y = [[0, 0, 1, 0, 0],  # unit experienced an event at t = 3
+                 [0, 1, 0, 0, 0],  # unit experienced an event at t = 2
+                 [0, 1, 1, 1, 1],] # unit was censored at t = 2
+        """
 
         # building times axis
         self.get_times(T, is_min_time_zero, extra_pct_time)
-        n_units  = T.shape[0]
-        
+        n_units = T.shape[0]
+
         # Initializing the output variable
         Y_cens, Y_uncens = [], []
         X_cens, X_uncens = [], []
 
         # Building the output variable
-        for i, (t, e) in enumerate( zip(T, E) ):
-            y = np.zeros(self.num_times+1)
-            min_abs_value = [abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets]
+        for i, (t, e) in enumerate(zip(T, E)):
+            y = np.zeros(self.num_times + 1)
+            min_abs_value = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_abs_value)
 
             if e == 1:
-                y[index] = 1.
-                X_uncens.append( X[i, :].tolist() )
-                Y_uncens.append( y.tolist() )
+                y[index] = 1.0
+                X_uncens.append(X[i, :].tolist())
+                Y_uncens.append(y.tolist())
 
-            else:                
-                y[(index):] = 1.
-                X_cens.append( X[i, :].tolist() )
-                Y_cens.append( y.tolist() )
+            else:
+                y[(index):] = 1.0
+                X_cens.append(X[i, :].tolist())
+                Y_cens.append(y.tolist())
 
         # Transform into torch.Tensor
         X_cens = torch.FloatTensor(X_cens)
@@ -150,73 +148,85 @@ class BaseMultiTaskModel(BaseModel):
         Y_cens = torch.FloatTensor(Y_cens)
         Y_uncens = torch.FloatTensor(Y_uncens)
 
-        return X_cens, X_uncens, Y_cens, Y_uncens 
-        
+        return X_cens, X_uncens, Y_cens, Y_uncens
 
-    def loss_function(self, model, X_cens, X_uncens, Y_cens, Y_uncens, 
-        Triangle, l2_reg, l2_smooth):
-        """ Computes the loss function of the any MTLR model. 
-            All the operations have been vectorized to ensure optimal speed
+    def loss_function(
+        self, model, X_cens, X_uncens, Y_cens, Y_uncens, Triangle, l2_reg, l2_smooth
+    ):
+        """Computes the loss function of the any MTLR model.
+        All the operations have been vectorized to ensure optimal speed
         """
 
         # Likelihood Calculations -- Uncensored
         score_uncens = model(X_uncens)
-        phi_uncens = torch.exp( torch.mm(score_uncens, Triangle) )
-        reduc_phi_uncens = torch.sum(phi_uncens*Y_uncens, dim = 1)
+        phi_uncens = torch.exp(torch.mm(score_uncens, Triangle))
+        reduc_phi_uncens = torch.sum(phi_uncens * Y_uncens, dim=1)
 
         # Likelihood Calculations -- Censored
         score_cens = model(X_cens)
-        phi_cens = torch.exp( torch.mm(score_cens, Triangle) )
-        reduc_phi_cens = torch.sum( phi_cens*Y_cens, dim = 1)
+        phi_cens = torch.exp(torch.mm(score_cens, Triangle))
+        reduc_phi_cens = torch.sum(phi_cens * Y_cens, dim=1)
 
         # Likelihood Calculations -- Normalization
-        z_uncens = torch.exp( torch.mm(score_uncens, Triangle) )
-        reduc_z_uncens = torch.sum( z_uncens, dim = 1)
+        z_uncens = torch.exp(torch.mm(score_uncens, Triangle))
+        reduc_z_uncens = torch.sum(z_uncens, dim=1)
 
-        z_cens = torch.exp( torch.mm(score_cens, Triangle) )
-        reduc_z_cens = torch.sum( z_cens, dim = 1)
+        z_cens = torch.exp(torch.mm(score_cens, Triangle))
+        reduc_z_cens = torch.sum(z_cens, dim=1)
 
         # MTLR cost function
-        loss = - (
-                    torch.sum( torch.log(reduc_phi_uncens) ) \
-                  + torch.sum( torch.log(reduc_phi_cens) )  \
-
-                  - torch.sum( torch.log(reduc_z_uncens) ) \
-                  - torch.sum( torch.log(reduc_z_cens) ) 
-                 )
+        loss = -(
+            torch.sum(torch.log(reduc_phi_uncens))
+            + torch.sum(torch.log(reduc_phi_cens))
+            - torch.sum(torch.log(reduc_z_uncens))
+            - torch.sum(torch.log(reduc_z_cens))
+        )
 
         # Adding the regularized loss
         nb_set_parameters = len(list(model.parameters()))
         for i, w in enumerate(model.parameters()):
-            loss += l2_reg*torch.sum(w*w)/2.
-            
+            loss += l2_reg * torch.sum(w * w) / 2.0
+
             if i >= nb_set_parameters - 2:
-                loss += l2_smooth*norm_diff(w)
-                
+                loss += l2_smooth * norm_diff(w)
+
         return loss
 
-
-    def fit(self, X, T, E, init_method = 'glorot_uniform', optimizer ='adam', 
-            lr = 1e-4, num_epochs = 1000, dropout = 0.2, l2_reg=1e-2, 
-            l2_smooth=1e-2, batch_normalization=False, bn_and_dropout=False,
-            verbose=True, extra_pct_time = 0.1, is_min_time_zero=True):
-        """ Fit the estimator based on the given parameters.
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        init_method="glorot_uniform",
+        optimizer="adam",
+        lr=1e-4,
+        num_epochs=1000,
+        dropout=0.2,
+        l2_reg=1e-2,
+        l2_smooth=1e-2,
+        batch_normalization=False,
+        bn_and_dropout=False,
+        verbose=True,
+        extra_pct_time=0.1,
+        is_min_time_zero=True,
+    ):
+        """Fit the estimator based on the given parameters.
 
         Parameters:
         -----------
         * `X` : **array-like**, *shape=(n_samples, n_features)* --
             The input samples.
 
-        * `T` : **array-like** -- 
+        * `T` : **array-like** --
             The target values describing when the event of interest or censoring
             occurred.
 
         * `E` : **array-like** --
-            The values that indicate if the event of interest occurred i.e.: 
-            E[i]=1 corresponds to an event, and E[i] = 0 means censoring, 
+            The values that indicate if the event of interest occurred i.e.:
+            E[i]=1 corresponds to an event, and E[i] = 0 means censoring,
             for all i.
 
-        * `init_method` : **str** *(default = 'glorot_uniform')* -- 
+        * `init_method` : **str** *(default = 'glorot_uniform')* --
             Initialization method to use. Here are the possible options:
 
             * `glorot_uniform`: Glorot/Xavier uniform initializer
@@ -229,7 +239,7 @@ class BaseMultiTaskModel(BaseModel):
             * `zeros`: Initializing tensors to 0
             * `orthogonal`: Initializing tensors with a orthogonal matrix,
 
-        * `optimizer`:  **str** *(default = 'adam')* -- 
+        * `optimizer`:  **str** *(default = 'adam')* --
             iterative method for optimizing a differentiable objective function.
             Here are the possible options:
 
@@ -241,39 +251,39 @@ class BaseMultiTaskModel(BaseModel):
             - `sparseadam`
             - `sgd`
 
-        * `lr`: **float** *(default=1e-4)* -- 
+        * `lr`: **float** *(default=1e-4)* --
             learning rate used in the optimization
 
-        * `num_epochs`: **int** *(default=1000)* -- 
+        * `num_epochs`: **int** *(default=1000)* --
             The number of iterations in the optimization
 
-        * `dropout`: **float** *(default=0.5)* -- 
-            Randomly sets a fraction rate of input units to 0 
+        * `dropout`: **float** *(default=0.5)* --
+            Randomly sets a fraction rate of input units to 0
             at each update during training time, which helps prevent overfitting.
 
-        * `l2_reg`: **float** *(default=1e-4)* -- 
+        * `l2_reg`: **float** *(default=1e-4)* --
             L2 regularization parameter for the model coefficients
 
-        * `l2_smooth`: **float** *(default=1e-4)* -- 
-            Second L2 regularizer that ensures the parameters vary smoothly 
+        * `l2_smooth`: **float** *(default=1e-4)* --
+            Second L2 regularizer that ensures the parameters vary smoothly
             across consecutive time points.
 
-        * `batch_normalization`: **bool** *(default=True)* -- 
+        * `batch_normalization`: **bool** *(default=True)* --
             Applying Batch Normalization or not
 
-        * `bn_and_dropout`: **bool** *(default=False)* -- 
+        * `bn_and_dropout`: **bool** *(default=False)* --
             Applying Batch Normalization and Dropout at the same time
 
-        * `display_loss`: **bool** *(default=True)* -- 
+        * `display_loss`: **bool** *(default=True)* --
             Whether or not showing the loss function values at each update
 
-        * `verbose`: **bool** *(default=True)* -- 
+        * `verbose`: **bool** *(default=True)* --
             Whether or not producing detailed logging about the modeling
 
-        * `extra_pct_time`: **float** *(default=0.1)* -- 
+        * `extra_pct_time`: **float** *(default=0.1)* --
             Providing an extra fraction of time in the time axis
 
-        * `is_min_time_zero`: **bool** *(default=True)* -- 
+        * `is_min_time_zero`: **bool** *(default=True)* --
             Whether the the time axis starts at 0
 
         **Returns:**
@@ -283,7 +293,7 @@ class BaseMultiTaskModel(BaseModel):
 
         Example:
         --------
-            
+
         #### 1 - Importing packages
         import numpy as np
         import pandas as pd
@@ -297,16 +307,16 @@ class BaseMultiTaskModel(BaseModel):
 
         #### 2 - Generating the dataset from a Weibull parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'Weibull',  
+        sim = SimulationModel( survival_distribution = 'Weibull',
                                risk_type = 'linear',
-                               censored_parameter = 10.0, 
+                               censored_parameter = 10.0,
                                alpha = .01, beta = 3.0 )
 
-        # Generating N random samples 
+        # Generating N random samples
         N = 1000
         dataset = sim.generate_data(num_samples = N, num_features = 3)
 
-        # Showing a few data-points 
+        # Showing a few data-points
         time_column = 'time'
         event_column = 'event'
         dataset.head(2)
@@ -327,12 +337,12 @@ class BaseMultiTaskModel(BaseModel):
 
         #### 4 - Initializing a MTLR model and fitting the data.
         # Building a Linear model
-        mtlr = LinearMultiTaskModel(bins=50) 
+        mtlr = LinearMultiTaskModel(bins=50)
         mtlr.fit(X_train, T_train, E_train, lr=5e-3, init_method='orthogonal')
 
         # Building a Neural MTLR
         # structure = [ {'activation': 'Swish', 'num_units': 150},  ]
-        # mtlr = NeuralMultiTaskModel(structure=structure, bins=150) 
+        # mtlr = NeuralMultiTaskModel(structure=structure, bins=150)
         # mtlr.fit(X_train, T_train, E_train, lr=5e-3, init_method='adam')
 
         #### 5 - Cross Validation / Model Performances
@@ -347,61 +357,78 @@ class BaseMultiTaskModel(BaseModel):
         # Extracting data parameters
         nb_units, self.num_vars = X.shape
         input_shape = self.num_vars
-    
-        # Scaling data 
+
+        # Scaling data
         if self.auto_scaler:
-            X = self.scaler.fit_transform( X ) 
+            X = self.scaler.fit_transform(X)
 
         # Building the time axis, time buckets and output Y
-        X_cens, X_uncens, Y_cens, Y_uncens \
-            = self.compute_XY(X, T, E, is_min_time_zero, extra_pct_time)
+        X_cens, X_uncens, Y_cens, Y_uncens = self.compute_XY(
+            X, T, E, is_min_time_zero, extra_pct_time
+        )
 
         # Initializing the model
-        model = nn.NeuralNet(input_shape, self.num_times, self.structure, 
-                             init_method, dropout, batch_normalization, 
-                             bn_and_dropout )
+        model = nn.NeuralNet(
+            input_shape,
+            self.num_times,
+            self.structure,
+            init_method,
+            dropout,
+            batch_normalization,
+            bn_and_dropout,
+        )
 
         # Creating the Triangular matrix
-        Triangle = np.tri(self.num_times, self.num_times + 1, dtype=np.float32) 
+        Triangle = np.tri(self.num_times, self.num_times + 1, dtype=np.float32)
         Triangle = torch.FloatTensor(Triangle)
 
         # Performing order 1 optimization
-        model, loss_values = opt.optimize(self.loss_function, model, optimizer, 
-            lr, num_epochs, verbose,  X_cens=X_cens, X_uncens=X_uncens, 
-            Y_cens=Y_cens, Y_uncens=Y_uncens, Triangle=Triangle, 
-            l2_reg=l2_reg, l2_smooth=l2_smooth)
+        model, loss_values = opt.optimize(
+            self.loss_function,
+            model,
+            optimizer,
+            lr,
+            num_epochs,
+            verbose,
+            X_cens=X_cens,
+            X_uncens=X_uncens,
+            Y_cens=Y_cens,
+            Y_uncens=Y_uncens,
+            Triangle=Triangle,
+            l2_reg=l2_reg,
+            l2_smooth=l2_smooth,
+        )
 
         # Saving attributes
         self.model = model.eval()
         self.loss_values = loss_values
 
         return self
-    
 
-    def predict(self, x, t = None):
-        """ Predicting the hazard, density and survival functions
-        
+    def predict(self, x, t=None):
+        """Predicting the hazard, density and survival functions
+
         Parameters:
         ----------
         * `x` : **array-like** *shape=(n_samples, n_features)* --
-            array-like representing the datapoints. 
+            array-like representing the datapoints.
             x should not be standardized before, the model
             will take care of it
 
         * `t`: **double** *(default=None)* --
-             time at which the prediction should be performed. 
+             time at which the prediction should be performed.
              If None, then return the function for all available t.
         """
-        
+
         # Convert x into the right format
         x = utils.check_data(x)
 
         # Scaling the data
         if self.auto_scaler:
             if x.ndim == 1:
-                x = self.scaler.transform( x.reshape(1, -1) )
+                x = self.scaler.transform(x.reshape(1, -1))
             elif x.ndim == 2:
-                x = self.scaler.transform( x )
+                x = self.scaler.transform(x)
         else:
             # Ensuring x has 2 dimensions
             if x.ndim == 1:
@@ -409,42 +436,41 @@ class BaseMultiTaskModel(BaseModel):
 
         # Transforming into pytorch objects
         x = torch.FloatTensor(x)
-                
+
         # Predicting using linear/nonlinear function
         score_torch = self.model(x)
         score = score_torch.data.numpy()
-                
+
         # Cretaing the time triangles
-        Triangle1 = np.tri(self.num_times , self.num_times + 1 )
-        Triangle2 = np.tri(self.num_times+1 , self.num_times + 1 )
+        Triangle1 = np.tri(self.num_times, self.num_times + 1)
+        Triangle2 = np.tri(self.num_times + 1, self.num_times + 1)
 
         # Calculating the score, density, hazard and Survival
-        phi = np.exp( np.dot(score, Triangle1) )
+        phi = np.exp(np.dot(score, Triangle1))
         div = np.repeat(np.sum(phi, 1).reshape(-1, 1), phi.shape[1], axis=1)
-        density = (phi/div)
+        density = phi / div
         Survival = np.dot(density, Triangle2)
-        hazard = density[:, :-1]/Survival[:, 1:]
+        hazard = density[:, :-1] / Survival[:, 1:]
 
         # Returning the full functions of just one time point
         if t is None:
             return hazard, density, Survival
         else:
-            min_abs_value = [abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets]
+            min_abs_value = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_abs_value)
             return hazard[:, index], density[:, index], Survival[:, index]
 
-
     def predict_risk(self, x, use_log=False):
-        """ Computing the risk score 
+        """Computing the risk score
 
         Parameters:
         -----------
         * `x` : **array-like** *shape=(n_samples, n_features)* --
-            array-like representing the datapoints. 
+            array-like representing the datapoints.
             x should not be standardized before, the model
             will take care of it
 
-        * `use_log`: **bool** *(default=True)* -- 
+        * `use_log`: **bool** *(default=True)* --
             Applies the log function to the risk values
 
         """
@@ -456,70 +482,91 @@ class BaseMultiTaskModel(BaseModel):
             return risk
 
 
-
 class LinearMultiTaskModel(BaseMultiTaskModel):
-    """ LinearMultiTaskModel is the original Multi-Task model, 
-        a.k.a the Multi-Task Logistic Regression model (MTLR).
-        It was first introduced by  Chun-Nam Yu et al. in 
-        Learning Patient-Specific Cancer Survival Distributions 
-        as a Sequence of Dependent Regressors
-        
-        Reference:
-        ----------
-            * http://www.cs.cornell.edu/~cnyu/papers/nips11_survival.pdf
-        
-        Parameters:
-        ----------
-            * bins: int 
-                Number of subdivisions of the time axis 
+    """LinearMultiTaskModel is the original Multi-Task model,
+    a.k.a the Multi-Task Logistic Regression model (MTLR).
+    It was first introduced by  Chun-Nam Yu et al. in
+    Learning Patient-Specific Cancer Survival Distributions
+    as a Sequence of Dependent Regressors
 
-            * auto_scaler: boolean (default=True)
-                Determines whether a sklearn scaler should be automatically 
-                applied
+    Reference:
+    ----------
+        * http://www.cs.cornell.edu/~cnyu/papers/nips11_survival.pdf
+
+    Parameters:
+    ----------
+        * bins: int
+            Number of subdivisions of the time axis
+
+        * auto_scaler: boolean (default=True)
+            Determines whether a sklearn scaler should be automatically
+            applied
 
     """
-    
-    def __init__(self, bins = 100, auto_scaler=True):
+
+    def __init__(self, bins=100, auto_scaler=True):
         super(LinearMultiTaskModel, self).__init__(
-            structure = None, bins = bins, auto_scaler=auto_scaler)
+            structure=None, bins=bins, auto_scaler=auto_scaler
+        )
 
-
-    def fit(self, X, T, E, init_method = 'glorot_uniform', optimizer ='adam', 
-            lr = 1e-4, num_epochs = 1000, l2_reg=1e-2, l2_smooth=1e-2, 
-            verbose=True, extra_pct_time = 0.1, is_min_time_zero=True):
-
-        super(LinearMultiTaskModel, self).fit(X=X, T=T, E=E, 
-            init_method = init_method, optimizer =optimizer, 
-            lr = lr, num_epochs = num_epochs, dropout = None, l2_reg=l2_reg, 
-            l2_smooth=l2_smooth, batch_normalization=False, 
-            bn_and_dropout=False, verbose=verbose, 
-            extra_pct_time = extra_pct_time, is_min_time_zero=is_min_time_zero)
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        init_method="glorot_uniform",
+        optimizer="adam",
+        lr=1e-4,
+        num_epochs=1000,
+        l2_reg=1e-2,
+        l2_smooth=1e-2,
+        verbose=True,
+        extra_pct_time=0.1,
+        is_min_time_zero=True,
+    ):
+        super(LinearMultiTaskModel, self).fit(
+            X=X,
+            T=T,
+            E=E,
+            init_method=init_method,
+            optimizer=optimizer,
+            lr=lr,
+            num_epochs=num_epochs,
+            dropout=None,
+            l2_reg=l2_reg,
+            l2_smooth=l2_smooth,
+            batch_normalization=False,
+            bn_and_dropout=False,
+            verbose=verbose,
+            extra_pct_time=extra_pct_time,
+            is_min_time_zero=is_min_time_zero,
+        )
 
         return self
-    
+
 
 class NeuralMultiTaskModel(BaseMultiTaskModel):
-    """ NeuralMultiTaskModel is the Neural Multi-Task Logistic Regression 
-        model (N-MTLR) was developed by Fotso S. in 
-        Deep Neural Networks for Survival Analysis Based on a 
-        Multi-Task Framework, 
+    """NeuralMultiTaskModel is the Neural Multi-Task Logistic Regression
+        model (N-MTLR) was developed by Fotso S. in
+        Deep Neural Networks for Survival Analysis Based on a
+        Multi-Task Framework,
         allowing the use of Neural Networks within the original design.
-        
+
     Reference:
     ----------
     * https://arxiv.org/pdf/1801.05512
 
     Parameters:
     ----------
-    * `structure`:  **list of dictionaries** -- 
+    * `structure`:  **list of dictionaries** --
         Provides the structure of the MLP built within the N-MTLR.
-        
+
         ex: `structure = [ {'activation': 'ReLU', 'num_units': 128}, ]`.
 
         Each dictionary corresponds to a fully connected hidden layer:
 
         * `units` is the number of hidden units in this layer
-        * `activation` is the activation function that will be used. 
+        * `activation` is the activation function that will be used.
         The list of all available activation functions can be found :
             * Atan
             * BentIdentity
@@ -544,63 +591,61 @@ class NeuralMultiTaskModel(BaseMultiTaskModel):
             * Softsign
             * Swish
             * Tanh
-    
-        In case there are more than one dictionary, 
-        each hidden layer will be applied in the resulting MLP, 
+
+        In case there are more than one dictionary,
+        each hidden layer will be applied in the resulting MLP,
         using the order it is provided in the structure:
-        ex: structure = [ {'activation': 'relu', 'num_units': 128}, 
-                          {'activation': 'tanh', 'num_units': 128}, ] 
+        ex: structure = [ {'activation': 'relu', 'num_units': 128},
+                          {'activation': 'tanh', 'num_units': 128}, ]
 
-    * `bins`: **int** *(default=100)* -- 
-         Number of subdivisions of the time axis 
+    * `bins`: **int** *(default=100)* --
+         Number of subdivisions of the time axis
 
-    * `auto_scaler`: **boolean** *(default=True)* -- 
+    * `auto_scaler`: **boolean** *(default=True)* --
         Determines whether a sklearn scaler should be automatically applied
     """
-    
-    def __init__(self, structure, bins = 100, auto_scaler = True):
 
+    def __init__(self, structure, bins=100, auto_scaler=True):
         # Checking the validity of structure
         structure = nn.check_mlp_structure(structure)
 
         # Initializing the instance
         super(NeuralMultiTaskModel, self).__init__(
-            structure = structure, bins = bins, auto_scaler = auto_scaler)
-    
-    
+            structure=structure, bins=bins, auto_scaler=auto_scaler
+        )
+
     def __repr__(self):
-        """ Representing the class object """
+        """Representing the class object"""
 
         if self.structure is None:
             super(NeuralMultiTaskModel, self).__repr__()
             return self.name
-            
+
         else:
             S = len(self.structure)
             self.name = self.__class__.__name__
             empty = len(self.name)
-            self.name += '( '
+            self.name += "( "
             for i, s in enumerate(self.structure):
-                n = 'Layer({}): '.format(i+1)
-                activation = nn.activation_function(s['activation'], 
-                    return_text=True)
-                n += 'activation = {}, '.format( s['activation'] )
-                n += 'units = {} '.format( s['num_units'] )
-                
-                if i != S-1:
-                    self.name += n + '; \n'
-                    self.name += empty*' ' + '  '
+                n = "Layer({}): ".format(i + 1)
+                activation = nn.activation_function(s["activation"], return_text=True)
+                n += "activation = {}, ".format(s["activation"])
+                n += "units = {} ".format(s["num_units"])
+
+                if i != S - 1:
+                    self.name += n + "; \n"
+                    self.name += empty * " " + "  "
                 else:
                     self.name += n
-            self.name = self.name + ')'
+            self.name = self.name + ")"
             return self.name
 
 
 def norm_diff(W):
-    """ Special norm function for the last layer of the MTLR """
-    dims=len(W.shape)
-    if dims==1:
-        diff = W[1:]-W[:-1]
-    elif dims==2:
-        diff = W[1:, :]-W[:-1, :]
-    return torch.sum(diff*diff)
+    """Special norm function for the last layer of the MTLR"""
+    dims = len(W.shape)
+    if dims == 1:
+        diff = W[1:] - W[:-1]
+    elif dims == 2:
+        diff = W[1:, :] - W[:-1, :]
+    return torch.sum(diff * diff)

--- a/pysurvival/models/non_parametric.py
+++ b/pysurvival/models/non_parametric.py
@@ -1,78 +1,76 @@
 from __future__ import absolute_import
+
 import os
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 from scipy import stats
+
 from pysurvival import utils
 from pysurvival.models import BaseModel
-from pysurvival.models._non_parametric import _KaplanMeierModel
-from pysurvival.models._non_parametric import _KernelModel
+from pysurvival.models._non_parametric import _KaplanMeierModel, _KernelModel
 
 
 class NonParametricModel(BaseModel):
-    """ Non Parametric Model
-        --------------------
+    """Non Parametric Model
+    --------------------
 
-        The Non Parametric Model object is tha base model for any Non Parametric 
-        models in pysurvival such as :
-        * Kaplan Meier model
-        * Smooth Kaplan Meier model
+    The Non Parametric Model object is tha base model for any Non Parametric
+    models in pysurvival such as :
+    * Kaplan Meier model
+    * Smooth Kaplan Meier model
 
-        This object should not be used on its own.
+    This object should not be used on its own.
     """
 
     def save(self, path_file):
-        """ Save the model paremeters of the model (.params) and Compress 
-            them into a zip file
+        """Save the model paremeters of the model (.params) and Compress
+        them into a zip file
         """
 
         # Ensuring the file has the proper name
-        folder_name = os.path.dirname(path_file) + '/'
+        folder_name = os.path.dirname(path_file) + "/"
         file_name = os.path.basename(path_file)
 
         # Checking if the folder is accessible
         if not os.access(folder_name, os.W_OK):
-            error_msg = '{} is not an accessible directory.'.format(folder_name)
+            error_msg = "{} is not an accessible directory.".format(folder_name)
             raise OSError(error_msg)
 
         # Delete the CPP object before saving
         del self.model
-        
+
         # Saving the model
         super(NonParametricModel, self).save(path_file)
 
         # Re-introduce the C++ object
-        if 'smooth' in self.name.lower() :
+        if "smooth" in self.name.lower():
             self.model = _KernelModel(self.bandwidth, self.kernel_type)
         else:
             self.model = _KaplanMeierModel()
         self.load_properties()
-        
 
     def load(self, path_file):
-        """ Load the model paremeters from a zip file into a C++ external
-            model 
-        """        
+        """Load the model paremeters from a zip file into a C++ external
+        model
+        """
 
         # Loading the model
         super(NonParametricModel, self).load(path_file)
 
         # Re-introduce the C++ object
-        if 'smooth' in self.name.lower() :
+        if "smooth" in self.name.lower():
             self.model = _KernelModel(self.bandwidth, self.kernel_type)
         else:
             self.model = _KaplanMeierModel()
         self.load_properties()
 
-
-
-
-    def fit(self, T,  E, weights = None, alpha=0.95):
-        """ Fitting the model according to the provided data.
+    def fit(self, T, E, weights=None, alpha=0.95):
+        """Fitting the model according to the provided data.
 
         Parameters:
         -----------
-        * `T` : **array-like** -- 
+        * `T` : **array-like** --
             The target values describing when the event of interest or censoring
             occurred.
 
@@ -80,7 +78,7 @@ class NonParametricModel(BaseModel):
             The values that indicate if the event of interest occurred i.e.: E[i]=1
             corresponds to an event, and E[i] = 0 symbols censoring, for all i.
 
-        * `weights` : **array-like** *(default = None)* -- 
+        * `weights` : **array-like** *(default = None)* --
             Array of weights that are assigned to individual samples.
             If not provided, then each sample is given a unit weight.
 
@@ -99,9 +97,9 @@ class NonParametricModel(BaseModel):
         import numpy as np
         from matplotlib import pyplot as plt
         from pysurvival.utils.display import display_non_parametric
-        # %matplotlib inline #Uncomment when using Jupyter 
+        # %matplotlib inline #Uncomment when using Jupyter
 
-        # Generating random times and event indicators 
+        # Generating random times and event indicators
         T = np.round(np.abs(np.random.normal(10, 10, 1000)), 1)
         E = np.random.binomial(1, 0.3, 1000)
 
@@ -109,7 +107,7 @@ class NonParametricModel(BaseModel):
         from pysurvival.models.non_parametric import KaplanMeierModel
         km_model = KaplanMeierModel()
 
-        # Fitting the model 
+        # Fitting the model
         km_model.fit(T, E, alpha=0.95)
 
         # Displaying the survival function and confidence intervals
@@ -126,19 +124,19 @@ class NonParametricModel(BaseModel):
         display_non_parametric(skm_model)
         """
 
-        # Checking the format of the data 
+        # Checking the format of the data
         T, E = utils.check_data(T, E)
 
         # weighting
         if weights is None:
-            weights = [1.]*T.shape[0]
+            weights = [1.0] * T.shape[0]
 
         # Confidence Intervals
-        z = stats.norm.ppf((1. - alpha) / 2.)
+        z = stats.norm.ppf((1.0 - alpha) / 2.0)
 
         # Building the Kaplan-Meier model
         survival = self.model.fit(T, E, weights, z)
-        if sum(survival) <= 0. :
+        if sum(survival) <= 0.0:
             mem_error = "The kernel matrix cannot fit in memory."
             mem_error += "You should use a bigger bandwidth b"
             raise MemoryError(mem_error)
@@ -147,9 +145,8 @@ class NonParametricModel(BaseModel):
         self.save_properties()
 
         # Generating the Survival table
-        if 'smooth' not in self.name.lower() :
+        if "smooth" not in self.name.lower():
             self.get_survival_table()
-
 
     def predict_cumulative_hazard(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
@@ -157,74 +154,67 @@ class NonParametricModel(BaseModel):
     def predict_risk(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
 
-
-    def predict_survival(self, t, is_lagged = False):
-        """ Extracting the predicted survival probabilities at the individual 
-            event times that have been used for fitting the model.
+    def predict_survival(self, t, is_lagged=False):
+        """Extracting the predicted survival probabilities at the individual
+        event times that have been used for fitting the model.
         """
         return self.model.predict_survival(t, is_lagged)
-        
 
-    def predict_survival_upper(self, t, is_lagged = False):
-        """ Extracting the predicted survival CI upper probabilities at the 
-            individual event times that have been used for fitting the model.
+    def predict_survival_upper(self, t, is_lagged=False):
+        """Extracting the predicted survival CI upper probabilities at the
+        individual event times that have been used for fitting the model.
         """
         return self.model.predict_survival_upper(t, is_lagged)
-        
 
-    def predict_survival_lower(self, t, is_lagged = False):
-        """ Extracting the predicted survival CI lower probabilities at the 
-            individual event times that have been used for fitting the model.
+    def predict_survival_lower(self, t, is_lagged=False):
+        """Extracting the predicted survival CI lower probabilities at the
+        individual event times that have been used for fitting the model.
         """
         return self.model.predict_survival_lower(t, is_lagged)
-        
 
-    def predict_density(self, t, is_lagged = False):
-        """ Extracting the predicted density probabilities at the individual 
-            event times that have been used for fitting the model.
+    def predict_density(self, t, is_lagged=False):
+        """Extracting the predicted density probabilities at the individual
+        event times that have been used for fitting the model.
         """
-        return self.model.predict_density( t, is_lagged)
+        return self.model.predict_density(t, is_lagged)
 
-
-    def predict_hazard(self, t, is_lagged = False):
-        """ Extracting the hazard function values at the individual 
-            event times that have been used for fitting the model.
+    def predict_hazard(self, t, is_lagged=False):
+        """Extracting the hazard function values at the individual
+        event times that have been used for fitting the model.
         """
-        return self.model.predict_hazard( t, is_lagged)
+        return self.model.predict_hazard(t, is_lagged)
 
+    def save_properties(self):
+        """Saving the C++ attributes in the Python object"""
+        self.times = np.array(self.model.times)
+        self.time_buckets = self.model.time_buckets
+        self.survival = np.array(self.model.survival)
+        self.hazard = np.array(self.model.hazard)
+        self.cumulative_hazard = np.array(self.model.cumulative_hazard)
 
-    def save_properties(self): 
-        """ Saving the C++ attributes in the Python object """
-        self.times  = np.array( self.model.times )
-        self.time_buckets  = self.model.time_buckets
-        self.survival  = np.array( self.model.survival )
-        self.hazard = np.array( self.model.hazard )
-        self.cumulative_hazard = np.array( self.model.cumulative_hazard )
-
-        if 'smooth' in self.name.lower() :
-            self.km_survival = np.array( self.model.km_survival )
-            self.km_times = np.array( self.model.km_times )
+        if "smooth" in self.name.lower():
+            self.km_survival = np.array(self.model.km_survival)
+            self.km_times = np.array(self.model.km_times)
             self.kernel_type = self.model.kernel_type
             self.bandwidth = self.model.b
-            self.kernel_matrix = np.array( self.model.kernel_matrix )
+            self.kernel_matrix = np.array(self.model.kernel_matrix)
 
         else:
-            self.std_error = np.array( self.model.std_error )
-            self.survival_ci_upper = np.array( self.model.survival_ci_upper )
-            self.survival_ci_lower = np.array( self.model.survival_ci_lower )
-            self.at_risk = np.array( self.model.at_risk )
-            self.events = np.array( self.model.events )
+            self.std_error = np.array(self.model.std_error)
+            self.survival_ci_upper = np.array(self.model.survival_ci_upper)
+            self.survival_ci_lower = np.array(self.model.survival_ci_lower)
+            self.at_risk = np.array(self.model.at_risk)
+            self.events = np.array(self.model.events)
 
-
-    def load_properties(self): 
-        """ Loading Python object attributes into the C++  """
-        self.model.times  = self.times
-        self.model.time_buckets  = self.time_buckets
-        self.model.survival  = self.survival
+    def load_properties(self):
+        """Loading Python object attributes into the C++"""
+        self.model.times = self.times
+        self.model.time_buckets = self.time_buckets
+        self.model.survival = self.survival
         self.model.hazard = self.hazard
         self.model.cumulative_hazard = self.cumulative_hazard
 
-        if 'smooth' in self.name.lower() :
+        if "smooth" in self.name.lower():
             self.model.kernel_type = self.kernel_type
             self.model.b = self.bandwidth
             self.model.kernel_matrix = self.kernel_matrix
@@ -237,46 +227,48 @@ class NonParametricModel(BaseModel):
             self.model.survival_ci_lower = self.survival_ci_lower
             self.model.at_risk = self.at_risk
             self.model.events = self.events
-            
 
     def get_survival_table(self):
-        """ Computing the survival table"""
+        """Computing the survival table"""
 
-        data = {'Time': self.times,
-                'Number at risk':self.at_risk,
-                'Number of events':self.events,
-                'Survival': self.survival,
-                'Survival - CI Lower': self.survival_ci_lower,
-                'Survival - CI Upper': self.survival_ci_upper, 
-                }
-        survival_df = pd.DataFrame(data,
-                                   columns = ['Time', 'Number at risk', 
-                                              'Number of events', 'Survival',
-                                              'Survival - CI Lower',
-                                              'Survival - CI Upper'] )
+        data = {
+            "Time": self.times,
+            "Number at risk": self.at_risk,
+            "Number of events": self.events,
+            "Survival": self.survival,
+            "Survival - CI Lower": self.survival_ci_lower,
+            "Survival - CI Upper": self.survival_ci_upper,
+        }
+        survival_df = pd.DataFrame(
+            data,
+            columns=[
+                "Time",
+                "Number at risk",
+                "Number of events",
+                "Survival",
+                "Survival - CI Lower",
+                "Survival - CI Upper",
+            ],
+        )
         self.survival_table = survival_df
         return survival_df
 
 
-
-
-
-
 class KaplanMeierModel(NonParametricModel):
 
-    """ Kaplan-Meier Model
+    """Kaplan-Meier Model
         ------------------
-        
-    The Kaplan-Meier estimator is a non-parametric statistic 
-    used to estimate the survival function from lifetime data. 
-    The estimator is named after Edward L. Kaplan and Paul Meier, 
-    who each submitted similar manuscripts 
+
+    The Kaplan-Meier estimator is a non-parametric statistic
+    used to estimate the survival function from lifetime data.
+    The estimator is named after Edward L. Kaplan and Paul Meier,
+    who each submitted similar manuscripts
     to the Journal of the American Statistical Association.
 
     The estimator is given by:
         S(t) = (1.-d_1/r_1)*...*(1.-d_i/r_i)*...*(1.-d_n/r_n)
-            t_i, a time when at least one event happened, 
-            d_i, the number of events that happened at time t_i 
+            t_i, a time when at least one event happened,
+            d_i, the number of events that happened at time t_i
             r_i, the individuals known to survive at t_i.
 
     References:
@@ -290,86 +282,83 @@ class KaplanMeierModel(NonParametricModel):
 
         # Saving the attributes
         self.__repr__()
-        self.not_implemented_error = "{} does not have this method."\
-            .format(self.name)
+        self.not_implemented_error = "{} does not have this method.".format(self.name)
 
 
 class SmoothKaplanMeierModel(NonParametricModel):
-    
-    """ SmoothKaplanMeierModel
-        ------------------------
-        Because the standard Kaplan-Meier estimator is a step function with jumps 
-        located only at the uncensored observations, when many data are censored, 
-        it can only have a few jumps with increasing sizes. Thus the accuracy of 
-        the estimation might not be acceptable. 
-        A Smooth estimator is a good alternative, since it is computed by 
-        giving mass to all the data, including the censored observations. (1)
-        
-        The current implementation is based on Nonparametric density estimation 
-        from censored data from W.J. Padgett and Diane T. McNichols (2)
-        It was also inspired by CDF and survival function estimation with 
-        infinite-order kernels from Berg and Politis(2)
-        
-        References:
-        -----------
-        * survPresmooth: An R Package for PreSmooth Estimation in Survival Analysis
-          https://www.jstatsoft.org/article/view/v054i11 (1)
-        * https://doi.org/10.1080/03610928408828780 (2)
-        * https://projecteuclid.org/download/pdfview_1/euclid.ejs/1261671304 (3)
 
-        Parameters:
-        -----------
-        * bandwidth: double (default=0.1)
-             controls the degree of the smoothing. The smaller it is the closer
-             to the original KM the function will be, but it will increase the 
-             computation time. If it is very large, the resulting model will be 
-             smoother than the estimator of KM, but it will stop being as accurate.
-             
-        * kernel: str (default='normal')
-            defines the type of kernel the model will be using. 
-            Here are the possible options:
-                * uniform: f(x) = 0 if |x|<1 else f(x) = 0.5
-                * epanechnikov: f(x) = 0 if |x|<=1 else f(x) = 0.75*(1. - x^2 )
-                * normal: f(x) = exp( -x*x/2.) / sqrt( 2*pi )
-                * biweight: f(x) = 0 if |x|<=1 else f(x)=(15./16)*(1.-x^2)^2
-                * triweight: f(x) = 0 if |x|<=1 else f(x)=(35./32)*(1.-x^2)^3
-                * Cosine:  f(x) = 0 if |x|<=1 else  f(x)=(pi/4.)*cos( pi*x/2. )  
+    """SmoothKaplanMeierModel
+    ------------------------
+    Because the standard Kaplan-Meier estimator is a step function with jumps
+    located only at the uncensored observations, when many data are censored,
+    it can only have a few jumps with increasing sizes. Thus the accuracy of
+    the estimation might not be acceptable.
+    A Smooth estimator is a good alternative, since it is computed by
+    giving mass to all the data, including the censored observations. (1)
+
+    The current implementation is based on Nonparametric density estimation
+    from censored data from W.J. Padgett and Diane T. McNichols (2)
+    It was also inspired by CDF and survival function estimation with
+    infinite-order kernels from Berg and Politis(2)
+
+    References:
+    -----------
+    * survPresmooth: An R Package for PreSmooth Estimation in Survival Analysis
+      https://www.jstatsoft.org/article/view/v054i11 (1)
+    * https://doi.org/10.1080/03610928408828780 (2)
+    * https://projecteuclid.org/download/pdfview_1/euclid.ejs/1261671304 (3)
+
+    Parameters:
+    -----------
+    * bandwidth: double (default=0.1)
+         controls the degree of the smoothing. The smaller it is the closer
+         to the original KM the function will be, but it will increase the
+         computation time. If it is very large, the resulting model will be
+         smoother than the estimator of KM, but it will stop being as accurate.
+
+    * kernel: str (default='normal')
+        defines the type of kernel the model will be using.
+        Here are the possible options:
+            * uniform: f(x) = 0 if |x|<1 else f(x) = 0.5
+            * epanechnikov: f(x) = 0 if |x|<=1 else f(x) = 0.75*(1. - x^2 )
+            * normal: f(x) = exp( -x*x/2.) / sqrt( 2*pi )
+            * biweight: f(x) = 0 if |x|<=1 else f(x)=(15./16)*(1.-x^2)^2
+            * triweight: f(x) = 0 if |x|<=1 else f(x)=(35./32)*(1.-x^2)^3
+            * Cosine:  f(x) = 0 if |x|<=1 else  f(x)=(pi/4.)*cos( pi*x/2. )
     """
 
-    def __init__(self,  bandwidth = 0.1, kernel = 'normal' ):
-
+    def __init__(self, bandwidth=0.1, kernel="normal"):
         # Kernel function
-        if kernel.lower() == 'uniform' : 
-            kernel_type = 0 # Uniform kernel 
-            kernel = 'Uniform'
-            
+        if kernel.lower() == "uniform":
+            kernel_type = 0  # Uniform kernel
+            kernel = "Uniform"
+
         elif kernel.lower().startswith("epa"):
-            kernel_type = 1 # Epanechnikov kernel 
-            kernel = 'Epanechnikov'
-            
-        elif kernel.lower() == "normal" : 
-            kernel_type = 2 # Normal kernel 
-            kernel = 'Normal'
-            
-        elif kernel.lower().startswith("bi"): 
-            kernel_type = 3 # Biweight kernel 
-            kernel = 'Biweight'
-            
-        elif kernel.lower().startswith("tri"): 
-            kernel_type = 4 # Triweight kernel 
-            kernel = 'Triweight'
-            
-        elif kernel.lower().startswith("cos"): 
-            kernel_type = 5 # Cosine kernel 
-            kernel = 'Cosine'
+            kernel_type = 1  # Epanechnikov kernel
+            kernel = "Epanechnikov"
+
+        elif kernel.lower() == "normal":
+            kernel_type = 2  # Normal kernel
+            kernel = "Normal"
+
+        elif kernel.lower().startswith("bi"):
+            kernel_type = 3  # Biweight kernel
+            kernel = "Biweight"
+
+        elif kernel.lower().startswith("tri"):
+            kernel_type = 4  # Triweight kernel
+            kernel = "Triweight"
+
+        elif kernel.lower().startswith("cos"):
+            kernel_type = 5  # Cosine kernel
+            kernel = "Cosine"
 
         else:
-            raise NotImplementedError('{} is not a valid kernel function.'
-                .format(kernel))
+            raise NotImplementedError("{} is not a valid kernel function.".format(kernel))
 
         # bandwidth
-        if bandwidth <= 0.:
-            raise ValueError('bandwidth has to be positive.')
+        if bandwidth <= 0.0:
+            raise ValueError("bandwidth has to be positive.")
 
         # Initializing the C++ object
         self.model = _KernelModel(bandwidth, kernel_type)
@@ -381,15 +370,10 @@ class SmoothKaplanMeierModel(NonParametricModel):
 
         # Creating the representation of the object
         self.__repr__()
-        self.not_implemented_error = "{} does not have this method."\
-            .format(self.name)
-
+        self.not_implemented_error = "{} does not have this method.".format(self.name)
 
     def __repr__(self):
-        """ Creates the representation of the Object """
+        """Creates the representation of the Object"""
         self.name = "{}(bandwith={:.2f}, kernel='{}')"
-        self.name = self.name.format(self.__class__.__name__, 
-            self.bandwidth, self.kernel) 
+        self.name = self.name.format(self.__class__.__name__, self.bandwidth, self.kernel)
         return self.name
-        
-

--- a/pysurvival/models/parametric.py
+++ b/pysurvival/models/parametric.py
@@ -1,83 +1,79 @@
 from __future__ import absolute_import
+
 import numpy as np
-import scipy 
 import torch
+
+from pysurvival import utils
 from pysurvival.models import BaseModel
-from pysurvival import utils, HAS_GPU
-from pysurvival.utils import optimization as opt
 from pysurvival.utils import neural_networks as nn
+from pysurvival.utils import optimization as opt
 
 
 class BaseParametricModel(BaseModel):
-    """ Base class for all the Parametric estimators:
-        ---------------------------------------------
+    """Base class for all the Parametric estimators:
+    ---------------------------------------------
 
-        Parametric models are special cases of the Cox proportional hazard
-        model where is is assumed that the baseline hazard has a specific 
-        parametric form.
-        
-        The BaseParametricModel object provides the necessary framework to use
-        the properties of parametric models. It should not be used on its own.
+    Parametric models are special cases of the Cox proportional hazard
+    model where is is assumed that the baseline hazard has a specific
+    parametric form.
 
-        Parameters
-        ----------
-        * bins: int (default=100)
-             Number of subdivisions of the time axis 
+    The BaseParametricModel object provides the necessary framework to use
+    the properties of parametric models. It should not be used on its own.
 
-        * auto_scaler: boolean (default=True)
-            Determines whether a sklearn scaler should be automatically applied
+    Parameters
+    ----------
+    * bins: int (default=100)
+         Number of subdivisions of the time axis
+
+    * auto_scaler: boolean (default=True)
+        Determines whether a sklearn scaler should be automatically applied
     """
 
-    def __init__(self, bins = 100, auto_scaler=True):
-            
+    def __init__(self, bins=100, auto_scaler=True):
         # Saving the attributes
         self.loss_values = []
         self.bins = bins
 
         # Initializing the elements from BaseModel
         super(BaseParametricModel, self).__init__(auto_scaler)
-        
-    
+
     def get_hazard_survival(self, model, x, t):
         pass
-    
 
-    def get_times(self, T, is_min_time_zero = True, extra_pct_time = 0.1):
-        """ Building the time axis (self.times) as well as the time intervals 
-            ( all the [ t(k-1), t(k) ) in the time axis.
+    def get_times(self, T, is_min_time_zero=True, extra_pct_time=0.1):
+        """Building the time axis (self.times) as well as the time intervals
+        ( all the [ t(k-1), t(k) ) in the time axis.
         """
 
         # Setting the min_time and max_time
         max_time = max(T)
-        if is_min_time_zero :
-            min_time = 0. 
+        if is_min_time_zero:
+            min_time = 0.0
         else:
             min_time = min(T)
-        
+
         # Setting optional extra percentage time
-        if 0. <= extra_pct_time <= 1.:
+        if 0.0 <= extra_pct_time <= 1.0:
             p = extra_pct_time
         else:
-            raise Exception("extra_pct_time has to be between [0, 1].") 
+            raise Exception("extra_pct_time has to be between [0, 1].")
 
         # Building time points and time buckets
-        self.times = np.linspace(min_time, max_time*(1. + p), self.bins)
+        self.times = np.linspace(min_time, max_time * (1.0 + p), self.bins)
         self.get_time_buckets()
         self.nb_times = len(self.time_buckets)
 
-
-
     def loss_function(self, model, X, T, E, l2_reg):
-        """ Computes the loss function of any Parametric models. 
-            All the operations have been vectorized to ensure optimal speed
+        """Computes the loss function of any Parametric models.
+        All the operations have been vectorized to ensure optimal speed
         """
-        
+
         # Adapting the optimization for the use of GPU
         # if HAS_GPU:
         #     X = X.cuda(async=True)
         #     T = T.cuda(async=True)
         #     E = E.cuda(async=True)
-        #     model = model.cuda()   
+        #     model = model.cuda()
 
         # Hazard & Survival calculations
         hazard, Survival = self.get_hazard_survival(model, X, T)
@@ -85,19 +81,29 @@ class BaseParametricModel(BaseModel):
         # Loss function calculations
         hazard = torch.max(hazard, torch.FloatTensor([1e-6]))
         Survival = torch.max(Survival, torch.FloatTensor([1e-6]))
-        loss = - torch.sum( E*torch.log(hazard) + torch.log(Survival) ) 
+        loss = -torch.sum(E * torch.log(hazard) + torch.log(Survival))
 
         # Adding the regularized loss
         for w in model.parameters():
-            loss += l2_reg*torch.sum(w*w)/2.
+            loss += l2_reg * torch.sum(w * w) / 2.0
 
         return loss
 
-    
-    def fit(self, X, T, E, init_method = 'glorot_uniform', optimizer ='adam', 
-            lr = 1e-4, num_epochs = 1000, l2_reg=1e-2, verbose=True, 
-            is_min_time_zero = True, extra_pct_time = 0.1):
-        """ 
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        init_method="glorot_uniform",
+        optimizer="adam",
+        lr=1e-4,
+        num_epochs=1000,
+        l2_reg=1e-2,
+        verbose=True,
+        is_min_time_zero=True,
+        extra_pct_time=0.1,
+    ):
+        """
         Fit the estimator based on the given parameters.
 
         Parameters:
@@ -105,20 +111,20 @@ class BaseParametricModel(BaseModel):
         * `X` : **array-like**, *shape=(n_samples, n_features)* --
             The input samples.
 
-        * `T` : **array-like** -- 
+        * `T` : **array-like** --
             The target values describing when the event of interest or censoring
             occurred.
 
         * `E` : **array-like** --
-            The values that indicate if the event of interest occurred i.e.: 
-            E[i]=1 corresponds to an event, and E[i] = 0 means censoring, 
+            The values that indicate if the event of interest occurred i.e.:
+            E[i]=1 corresponds to an event, and E[i] = 0 means censoring,
             for all i.
 
-        * `init_method` : **str** *(default = 'glorot_uniform')* -- 
+        * `init_method` : **str** *(default = 'glorot_uniform')* --
             Initialization method to use. Here are the possible options:
 
-            * `glorot_uniform`:  Glorot/Xavier uniform initializer 
-            * `he_uniform`:  He uniform variance scaling initializer 
+            * `glorot_uniform`:  Glorot/Xavier uniform initializer
+            * `he_uniform`:  He uniform variance scaling initializer
             * `uniform`: Initializing tensors with uniform (-1, 1) distribution
             * `glorot_normal`: Glorot normal initializer,
             * `he_normal`: He normal initializer.
@@ -127,7 +133,7 @@ class BaseParametricModel(BaseModel):
             * `zeros`: Initializing tensors to 0
             * `orthogonal`: Initializing tensors with a orthogonal matrix,
 
-        * `optimizer`:  **str** *(default = 'adam')* -- 
+        * `optimizer`:  **str** *(default = 'adam')* --
             iterative method for optimizing a differentiable objective function.
             Here are the possible options:
 
@@ -139,22 +145,22 @@ class BaseParametricModel(BaseModel):
             - `sparseadam`
             - `sgd`
 
-        * `lr`: **float** *(default=1e-4)* -- 
+        * `lr`: **float** *(default=1e-4)* --
             learning rate used in the optimization
 
-        * `num_epochs`: **int** *(default=1000)* -- 
+        * `num_epochs`: **int** *(default=1000)* --
             The number of iterations in the optimization
 
-        * `l2_reg`: **float** *(default=1e-4)* -- 
+        * `l2_reg`: **float** *(default=1e-4)* --
             L2 regularization parameter for the model coefficients
 
-        * `verbose`: **bool** *(default=True)* -- 
+        * `verbose`: **bool** *(default=True)* --
             Whether or not producing detailed logging about the modeling
 
-        * `extra_pct_time`: **float** *(default=0.1)* -- 
+        * `extra_pct_time`: **float** *(default=0.1)* --
             Providing an extra fraction of time in the time axis
 
-        * `is_min_time_zero`: **bool** *(default=True)* -- 
+        * `is_min_time_zero`: **bool** *(default=True)* --
             Whether the the time axis starts at 0
 
         Returns:
@@ -178,16 +184,16 @@ class BaseParametricModel(BaseModel):
 
         #### 2 - Generating the dataset from a Gompertz parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'Gompertz',  
+        sim = SimulationModel( survival_distribution = 'Gompertz',
                                risk_type = 'linear',
-                               censored_parameter = 10.0, 
+                               censored_parameter = 10.0,
                                alpha = .01, beta = 3.0 )
 
-        # Generating N random samples 
+        # Generating N random samples
         N = 1000
         dataset = sim.generate_data(num_samples = N, num_features = 3)
 
-        # Showing a few data-points 
+        # Showing a few data-points
         time_column = 'time'
         event_column = 'event'
         dataset.head(2)
@@ -208,7 +214,7 @@ class BaseParametricModel(BaseModel):
 
         #### 4 - Creating an instance of the Gompertz model and fitting the data
         # Building the model
-        gomp_model = GompertzModel() 
+        gomp_model = GompertzModel()
         gomp_model.fit(X_train, T_train, E_train, lr=1e-2, init_method='zeros',
             optimizer ='adam', l2_reg = 1e-3, num_epochs=2000)
 
@@ -216,11 +222,11 @@ class BaseParametricModel(BaseModel):
         c_index = concordance_index(gomp_model, X_test, T_test, E_test) #0.8
         print('C-index: {:.2f}'.format(c_index))
 
-        ibs = integrated_brier_score(gomp_model, X_test, T_test, E_test, 
+        ibs = integrated_brier_score(gomp_model, X_test, T_test, E_test,
             t_max=30, figure_size=(20, 6.5) )
 
         """
-        
+
         # Checking data format (i.e.: transforming into numpy array)
         X, T, E = utils.check_data(X, T, E)
         T = np.maximum(T, 1e-6)
@@ -229,22 +235,21 @@ class BaseParametricModel(BaseModel):
         # Extracting data parameters
         nb_units, self.num_vars = X.shape
         input_shape = self.num_vars
-    
-        # Scaling data 
+
+        # Scaling data
         if self.auto_scaler:
-            X = self.scaler.fit_transform( X ) 
+            X = self.scaler.fit_transform(X)
 
         # Does the model need a parameter called Beta
         is_beta_used = True
-        init_alpha = 1.
-        if self.name == 'ExponentialModel':
+        init_alpha = 1.0
+        if self.name == "ExponentialModel":
             is_beta_used = False
-        if self.name == 'GompertzModel':
-            init_alpha = 1000.
+        if self.name == "GompertzModel":
+            init_alpha = 1000.0
 
         # Initializing the model
-        model = nn.ParametricNet(input_shape, init_method, init_alpha, 
-            is_beta_used)
+        model = nn.ParametricNet(input_shape, init_method, init_alpha, is_beta_used)
 
         # Trasnforming the inputs into tensors
         X = torch.FloatTensor(X)
@@ -252,24 +257,33 @@ class BaseParametricModel(BaseModel):
         E = torch.FloatTensor(E.reshape(-1, 1))
 
         # Performing order 1 optimization
-        model, loss_values = opt.optimize(self.loss_function, model, optimizer, 
-            lr, num_epochs, verbose,  X=X, T=T, E=E, l2_reg=l2_reg)
-        
+        model, loss_values = opt.optimize(
+            self.loss_function,
+            model,
+            optimizer,
+            lr,
+            num_epochs,
+            verbose,
+            X=X,
+            T=T,
+            E=E,
+            l2_reg=l2_reg,
+        )
+
         # Saving attributes
         self.model = model.eval()
         self.loss_values = loss_values
 
         # Calculating the AIC
-        self.aic = 2*self.loss_values[-1] 
-        self.aic -= 2*(self.num_vars + 1 + is_beta_used*1. - 1)
+        self.aic = 2 * self.loss_values[-1]
+        self.aic -= 2 * (self.num_vars + 1 + is_beta_used * 1.0 - 1)
 
         return self
-    
-    
-    def predict(self, x, t = None):
-        """ 
+
+    def predict(self, x, t=None):
+        """
         Predicting the hazard, density and survival functions
-        
+
         Arguments:
         ----------
             * x: pd.Dataframe or np.ndarray or list
@@ -278,16 +292,16 @@ class BaseParametricModel(BaseModel):
                 will take care of it
             * t: float (default=None)
                 Time at which hazard, density and survival functions
-                should be calculated. If None, the method returns 
-                the functions for all times t. 
+                should be calculated. If None, the method returns
+                the functions for all times t.
         """
-        
+
         # Scaling the data
         if self.auto_scaler:
             if x.ndim == 1:
-                x = self.scaler.transform( x.reshape(1, -1) )
+                x = self.scaler.transform(x.reshape(1, -1))
             elif x.ndim == 2:
-                x = self.scaler.transform( x )
+                x = self.scaler.transform(x)
         else:
             # Ensuring x has 2 dimensions
             if x.ndim == 1:
@@ -296,31 +310,30 @@ class BaseParametricModel(BaseModel):
         # Transforming into pytorch objects
         x = torch.FloatTensor(x)
         times = torch.FloatTensor(self.times.flatten())
-            
+
         # Calculating hazard, density, Survival
         hazard, Survival = self.get_hazard_survival(self.model, x, times)
-        density = hazard*Survival
+        density = hazard * Survival
 
         # Transforming into numpy objects
         hazard = hazard.data.numpy()
         density = density.data.numpy()
         Survival = Survival.data.numpy()
-            
+
         # Returning the full functions of just one time point
         if t is None:
             return hazard, density, Survival
         else:
-            min_abs_value = [abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets]
+            min_abs_value = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_abs_value)
             return hazard[:, index], density[:, index], Survival[:, index]
 
 
-
 class ExponentialModel(BaseParametricModel):
-    """ 
+    """
     ExponentialModel:
     -----------------
-        
+
     The exponential distribution is the simplest and most
     important distribution in survival studies. Being independent
     of prior information, it is known as a "lack of
@@ -329,48 +342,46 @@ class ExponentialModel(BaseParametricModel):
     (Application of Parametric Models to a Survival Analysis of
     Hemodialysis Patients)
     """
-    
+
     def get_hazard_survival(self, model, x, t):
-        """ Computing the hazard and Survival functions. """
-        
+        """Computing the hazard and Survival functions."""
+
         # Computing the score
-        score  = model(x).reshape(-1, 1)
+        score = model(x).reshape(-1, 1)
 
         # Computing hazard and Survival
-        hazard   = score
-        Survival = torch.exp(-hazard*t)   
-            
-        return hazard, Survival
+        hazard = score
+        Survival = torch.exp(-hazard * t)
 
+        return hazard, Survival
 
 
 class WeibullModel(BaseParametricModel):
     """
     WeibullModel:
     -------------
-    
+
     The Weibull distribution is a generalized form of the exponential
-    distribution and is de facto more flexible than the exponential model. 
+    distribution and is de facto more flexible than the exponential model.
     It is a two-parameter model (alpha and beta):
         * alpha is the location parameter
-        * beta is the shape parameter 
+        * beta is the shape parameter
     """
 
     def get_hazard_survival(self, model, x, t):
-        """ Computing the hazard and Survival functions. """
-        
+        """Computing the hazard and Survival functions."""
+
         # Computing the score
-        score  = model(x).reshape(-1, 1)
+        score = model(x).reshape(-1, 1)
 
         # Extracting beta
         beta = list(model.parameters())[-1]
 
         # Computing hazard and Survival
-        hazard   = beta*score*torch.pow(t, beta-1) 
-        Survival = torch.exp(- score*torch.pow(t, beta) )  
-        
-        return hazard, Survival
+        hazard = beta * score * torch.pow(t, beta - 1)
+        Survival = torch.exp(-score * torch.pow(t, beta))
 
+        return hazard, Survival
 
 
 class GompertzModel(BaseParametricModel):
@@ -378,55 +389,54 @@ class GompertzModel(BaseParametricModel):
     GompertzModel:
     --------------
 
-    The Gompertz distribution is a continuous probability distribution,  
-    that has an exponentially increasing failure rate, and is often 
+    The Gompertz distribution is a continuous probability distribution,
+    that has an exponentially increasing failure rate, and is often
     applied to analyze survival data.
-    
+
     """
 
     def get_hazard_survival(self, model, x, t):
-        """ Computing the hazard and Survival functions. """
-        
+        """Computing the hazard and Survival functions."""
+
         # Computing the score
-        score  = model(x).reshape(-1, 1)
+        score = model(x).reshape(-1, 1)
 
         # Extracting beta
         beta = list(model.parameters())[-1]
 
         # Computing hazard and Survival
-        hazard   = score*torch.exp(beta*t)
-        Survival = torch.exp(-score/beta*(torch.exp(beta*t)-1) )
-        
+        hazard = score * torch.exp(beta * t)
+        Survival = torch.exp(-score / beta * (torch.exp(beta * t) - 1))
+
         return hazard, Survival
-    
 
 
 class LogLogisticModel(BaseParametricModel):
     """
     LogLogisticModel:
     ----------------
-    
-    As the name suggests, the log-logistic distribution is the distribution 
-    of a variable whose logarithm has the logistic distribution. 
+
+    As the name suggests, the log-logistic distribution is the distribution
+    of a variable whose logarithm has the logistic distribution.
     The log-logistic distribution is often used to model random lifetimes.
     (http://www.randomservices.org/random/special/LogLogistic.html)
-    
+
     """
 
     def get_hazard_survival(self, model, x, t):
-        """ Computing the hazard and Survival functions. """
-        
+        """Computing the hazard and Survival functions."""
+
         # Computing the score
-        score  = model(x).reshape(-1, 1)
+        score = model(x).reshape(-1, 1)
 
         # Extracting beta
         beta = list(model.parameters())[-1]
 
         # Computing hazard and Survival
-        hazard  = score*beta*torch.pow(t, beta-1)
-        hazard  = hazard/(1 + score*torch.pow(t, beta) )
-        Survival = 1./(1. + torch.pow(score*t, beta) ) 
-        
+        hazard = score * beta * torch.pow(t, beta - 1)
+        hazard = hazard / (1 + score * torch.pow(t, beta))
+        Survival = 1.0 / (1.0 + torch.pow(score * t, beta))
+
         return hazard, Survival
 
 
@@ -434,32 +444,33 @@ class LogNormalModel(BaseParametricModel):
     """
     LogNormalModel:
     ---------------
-    
-    The lognormal distribution is used to model continuous random quantities 
+
+    The lognormal distribution is used to model continuous random quantities
     when the distribution is believed to be skewed, such as lifetime variables
     (http://www.randomservices.org/random/special/LogNormal.html)
-    
+
     """
 
     def get_hazard_survival(self, model, x, t):
-        """ Computing the hazard and Survival functions. """
-        
+        """Computing the hazard and Survival functions."""
+
         # Computing the score
-        score  = model(x).reshape(-1, 1)
+        score = model(x).reshape(-1, 1)
 
         # Extracting beta
         beta = list(model.parameters())[-1]
 
         # Initializing the Normal distribution
         from torch.distributions.normal import Normal
+
         m = Normal(torch.tensor([0.0]), torch.tensor([1.0]))
 
         # Computing hazard and Survival
-        hazard =  (torch.log(t) - torch.log(score))/(np.sqrt(2)*beta)
-        Survival = 1. - m.cdf((torch.log(t)-torch.log(score))/(np.sqrt(2)*beta))
-        hazard = hazard*(torch.log(t) - torch.log(score))/(np.sqrt(2)*beta)
-        hazard = torch.exp( -hazard/2.)
-        hazard = hazard/(np.sqrt(2*np.pi)*Survival*(t*beta))
+        hazard = (torch.log(t) - torch.log(score)) / (np.sqrt(2) * beta)
+        Survival = 1.0 - m.cdf((torch.log(t) - torch.log(score)) / (np.sqrt(2) * beta))
+        hazard = hazard * (torch.log(t) - torch.log(score)) / (np.sqrt(2) * beta)
+        hazard = torch.exp(-hazard / 2.0)
+        hazard = hazard / (np.sqrt(2 * np.pi) * Survival * (t * beta))
 
         hazard = torch.max(hazard, torch.FloatTensor([1e-6]))
         Survival = torch.max(Survival, torch.FloatTensor([1e-6]))

--- a/pysurvival/models/semi_parametric.py
+++ b/pysurvival/models/semi_parametric.py
@@ -1,101 +1,108 @@
 from __future__ import absolute_import
-import torch 
+
 import numpy as np
 import pandas as pd
 import scipy
-import copy
-from pysurvival import HAS_GPU
+import torch
+
 from pysurvival import utils
+from pysurvival.models import BaseModel
+from pysurvival.models._coxph import _baseline_functions, _CoxPHModel
 from pysurvival.utils import neural_networks as nn
 from pysurvival.utils import optimization as opt
-from pysurvival.models import BaseModel
-from pysurvival.models._coxph import _CoxPHModel
-from pysurvival.models._coxph import _baseline_functions
 
 
 class CoxPHModel(BaseModel):
-    """ Cox proportional hazards model:
-        -------------------------------
-        The purpose of the model is to evaluate simultaneously 
-        the effect of several factors on survival. 
-        In other words, it allows us to examine how specified factors 
-        influence the rate of a particular event happening 
-        at a particular point in time. 
-        
-        The Cox model is expressed by the hazard function h(t)
-        (the risk of dying at time t. )
-        It can be estimated as follow:
-            h(t, x)=h_0(t)*exp(<x, W>)
+    """Cox proportional hazards model:
+    -------------------------------
+    The purpose of the model is to evaluate simultaneously
+    the effect of several factors on survival.
+    In other words, it allows us to examine how specified factors
+    influence the rate of a particular event happening
+    at a particular point in time.
 
-        Then the Survival function can be calculated as follow:
-            H(t, x) = cumsum( h(t, x) )
-            S(t, x) = exp( -H(t, x) )
+    The Cox model is expressed by the hazard function h(t)
+    (the risk of dying at time t. )
+    It can be estimated as follow:
+        h(t, x)=h_0(t)*exp(<x, W>)
 
-        Reference:
-            * http://www.sthda.com/english/wiki/cox-proportional-hazards-model
+    Then the Survival function can be calculated as follow:
+        H(t, x) = cumsum( h(t, x) )
+        S(t, x) = exp( -H(t, x) )
+
+    Reference:
+        * http://www.sthda.com/english/wiki/cox-proportional-hazards-model
     """
 
-    def get_summary(self, alpha = 0.95, precision=3):
-        """ Providing the summary of the regression results:
-                * standard errors
-                * z-score 
-                * p-value
+    def get_summary(self, alpha=0.95, precision=3):
+        """Providing the summary of the regression results:
+        * standard errors
+        * z-score
+        * p-value
         """
-        
-        # Flattening the coef 
+
+        # Flattening the coef
         W_flat = self.weights.flatten()
 
-        # calculating standard error 
-        self.std_err  = np.sqrt(self.inv_Hessian.diagonal())/self.std_scale   
+        # calculating standard error
+        self.std_err = np.sqrt(self.inv_Hessian.diagonal()) / self.std_scale
 
-        # Confidence Intervals 
-        alpha = scipy.stats.norm.ppf((1. + alpha) / 2.)
-        lower_ci = np.round( W_flat - alpha * self.std_err, precision)
-        upper_ci = np.round( W_flat + alpha * self.std_err, precision)
-        z = np.round(W_flat / self.std_err , precision)
-        p_values = np.round(scipy.stats.chi2.sf( np.square(z), 1), precision)
+        # Confidence Intervals
+        alpha = scipy.stats.norm.ppf((1.0 + alpha) / 2.0)
+        lower_ci = np.round(W_flat - alpha * self.std_err, precision)
+        upper_ci = np.round(W_flat + alpha * self.std_err, precision)
+        z = np.round(W_flat / self.std_err, precision)
+        p_values = np.round(scipy.stats.chi2.sf(np.square(z), 1), precision)
         W = np.round(W_flat, precision)
         std_err = np.round(self.std_err, precision)
-        
+
         # Creating summary
-        df = np.c_[self.variables, W, std_err, 
-                    lower_ci, upper_ci, z, p_values]
-        df = pd.DataFrame(data = df,
-                          columns = ['variables', 'coef', 'std. err', 
-                                     'lower_ci', 'upper_ci',
-                                     'z', 'p_values'])
+        df = np.c_[self.variables, W, std_err, lower_ci, upper_ci, z, p_values]
+        df = pd.DataFrame(
+            data=df,
+            columns=["variables", "coef", "std. err", "lower_ci", "upper_ci", "z", "p_values"],
+        )
         self.summary = df
 
         return df
 
-    
-    def fit(self, X, T, E, init_method='glorot_normal', lr = 1e-2, 
-            max_iter = 100, l2_reg = 1e-2, alpha = 0.95,
-            tol = 1e-3, verbose = True ):
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        init_method="glorot_normal",
+        lr=1e-2,
+        max_iter=100,
+        l2_reg=1e-2,
+        alpha=0.95,
+        tol=1e-3,
+        verbose=True,
+    ):
         """
         Fitting a proportional hazards regression model using
         the Efron's approximation method to take into account tied times.
-        
-        As the Hessian matrix of the log-likelihood can be 
-        calculated without too much effort, the model parameters are 
+
+        As the Hessian matrix of the log-likelihood can be
+        calculated without too much effort, the model parameters are
         computed using the Newton_Raphson Optimization scheme:
                 W_new = W_old - lr*<Hessian^(-1), gradient>
-        
+
         Arguments:
         ---------
         * `X` : **array-like**, *shape=(n_samples, n_features)* --
             The input samples.
 
-        * `T` : **array-like** -- 
-            The target values describing when the event of interest or 
+        * `T` : **array-like** --
+            The target values describing when the event of interest or
             censoring occurred.
 
         * `E` : **array-like** --
-            The values that indicate if the event of interest occurred 
-            i.e.: E[i]=1 corresponds to an event, and E[i] = 0 means censoring, 
+            The values that indicate if the event of interest occurred
+            i.e.: E[i]=1 corresponds to an event, and E[i] = 0 means censoring,
             for all i.
 
-        * `init_method` : **str** *(default = 'glorot_uniform')* -- 
+        * `init_method` : **str** *(default = 'glorot_uniform')* --
             Initialization method to use. Here are the possible options:
 
             * `glorot_uniform`: Glorot/Xavier uniform initializer
@@ -107,25 +114,25 @@ class CoxPHModel(BaseModel):
             * `ones`: Initializing tensors to 1
             * `zeros`: Initializing tensors to 0
             * `orthogonal`: Initializing tensors with a orthogonal matrix,
-            
-        * `lr`: **float** *(default=1e-4)* -- 
+
+        * `lr`: **float** *(default=1e-4)* --
             learning rate used in the optimization
 
-        * `max_iter`: **int** *(default=100)* -- 
+        * `max_iter`: **int** *(default=100)* --
             The maximum number of iterations in the Newton optimization
 
-        * `l2_reg`: **float** *(default=1e-4)* -- 
+        * `l2_reg`: **float** *(default=1e-4)* --
             L2 regularization parameter for the model coefficients
 
-        * `alpha`: **float** *(default=0.95)* -- 
+        * `alpha`: **float** *(default=0.95)* --
             Confidence interval
 
-        * `tol`: **float** *(default=1e-3)* -- 
+        * `tol`: **float** *(default=1e-3)* --
             Tolerance for stopping criteria
 
-        * `verbose`: **bool** *(default=True)* -- 
+        * `verbose`: **bool** *(default=True)* --
             Whether or not producing detailed logging about the modeling
- 
+
         Example:
         --------
 
@@ -143,12 +150,12 @@ class CoxPHModel(BaseModel):
 
         #### 2 - Generating the dataset from a Log-Logistic parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'log-logistic',  
+        sim = SimulationModel( survival_distribution = 'log-logistic',
                                risk_type = 'linear',
-                               censored_parameter = 10.1, 
+                               censored_parameter = 10.1,
                                alpha = 0.1, beta=1.2 )
 
-        # Generating N random samples 
+        # Generating N random samples
         N = 1000
         dataset = sim.generate_data(num_samples = N, num_features = 3)
 
@@ -170,7 +177,7 @@ class CoxPHModel(BaseModel):
         #### 4 - Creating an instance of the Cox PH model and fitting the data.
         # Building the model
         coxph = CoxPHModel()
-        coxph.fit(X_train, T_train, E_train, lr=0.5, l2_reg=1e-2, 
+        coxph.fit(X_train, T_train, E_train, lr=0.5, l2_reg=1e-2,
             init_method='zeros')
 
 
@@ -178,31 +185,31 @@ class CoxPHModel(BaseModel):
         c_index = concordance_index(coxph, X_test, T_test, E_test) #0.92
         print('C-index: {:.2f}'.format(c_index))
 
-        ibs = integrated_brier_score(coxph, X_test, T_test, E_test, t_max=10, 
+        ibs = integrated_brier_score(coxph, X_test, T_test, E_test, t_max=10,
                     figure_size=(20, 6.5) )
 
         References:
         -----------
         * https://en.wikipedia.org/wiki/Proportional_hazards_model#Tied_times
-        * Efron, Bradley (1974). "The Efficiency of Cox's Likelihood 
-          Function for Censored Data". Journal of the American Statistical 
-          Association. 72 (359): 557-565. 
+        * Efron, Bradley (1974). "The Efficiency of Cox's Likelihood
+          Function for Censored Data". Journal of the American Statistical
+          Association. 72 (359): 557-565.
         """
-        
+
         # Collecting features names
         N, self.num_vars = X.shape
         if isinstance(X, pd.DataFrame):
             self.variables = X.columns.tolist()
         else:
-            self.variables = ['x_{}'.format(i) for i in range(self.num_vars)]
+            self.variables = ["x_{}".format(i) for i in range(self.num_vars)]
 
-        # Checking the format of the data 
+        # Checking the format of the data
         X, T, E = utils.check_data(X, T, E)
         order = np.argsort(-T)
         T = T[order]
         E = E[order]
-        X = self.scaler.fit_transform( X[order, :] )
-        self.std_scale = np.sqrt( self.scaler.var_ )
+        X = self.scaler.fit_transform(X[order, :])
+        self.std_scale = np.sqrt(self.scaler.var_)
 
         # Initializing the model
         self.model = _CoxPHModel()
@@ -210,47 +217,44 @@ class CoxPHModel(BaseModel):
         # Creating the time axis
         self.model.get_times(T, E)
 
-        # Initializing the parameters 
+        # Initializing the parameters
         W = np.zeros(self.num_vars)
         W = opt.initialization(init_method, W, False).flatten()
         W = W.astype(np.float64)
-        
-        # Optimizing to find best parameters 
-        epsilon=1e-9
-        self.model.newton_optimization(X, T, E, W, lr, l2_reg, tol, epsilon, 
-            max_iter, verbose)
-        
+
+        # Optimizing to find best parameters
+        epsilon = 1e-9
+        self.model.newton_optimization(X, T, E, W, lr, l2_reg, tol, epsilon, max_iter, verbose)
+
         # Saving the Cython attributes in the Python object
-        self.weights = np.array( self.model.W )
+        self.weights = np.array(self.model.W)
         self.loss = self.model.loss
-        self.times = np.array( self.model.times)
-        self.gradient = np.array( self.model.gradient )
-        self.Hessian = np.array( self.model.Hessian )
-        self.inv_Hessian = np.array( self.model.inv_Hessian )
-        self.loss_values = np.array( self.model.loss_values )
-        self.grad2_values = np.array( self.model.grad2_values )
+        self.times = np.array(self.model.times)
+        self.gradient = np.array(self.model.gradient)
+        self.Hessian = np.array(self.model.Hessian)
+        self.inv_Hessian = np.array(self.model.inv_Hessian)
+        self.loss_values = np.array(self.model.loss_values)
+        self.grad2_values = np.array(self.model.grad2_values)
 
         # Computing baseline functions
-        score = np.exp( np.dot(X, self.weights) )
+        score = np.exp(np.dot(X, self.weights))
         baselines = _baseline_functions(score, T, E)
 
         # Saving the Cython attributes in the Python object
-        self.baseline_hazard = np.array( baselines[1] )
-        self.baseline_survival = np.array( baselines[2] )
+        self.baseline_hazard = np.array(baselines[1])
+        self.baseline_survival = np.array(baselines[2])
         del self.model
         self.get_time_buckets()
 
-        # Calculating summary 
+        # Calculating summary
         self.get_summary(alpha)
 
         return self
-    
-    
-    
-    def predict(self, x, t = None):
-        """ 
+
+    def predict(self, x, t=None):
+        """
         Predicting the hazard, density and survival functions
-        
+
         Arguments:
             * x: pd.Dataframe or np.ndarray or list
                 x is the testing dataset containing the features
@@ -258,211 +262,211 @@ class CoxPHModel(BaseModel):
                 will take care of it
             * t: float (default=None)
                 Time at which hazard, density and survival functions
-                should be calculated. If None, the method returns 
-                the functions for all times t. 
+                should be calculated. If None, the method returns
+                the functions for all times t.
         """
-        
+
         # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Sacling the dataset
         if x.ndim == 1:
-            x = self.scaler.transform( x.reshape(1, -1) )
+            x = self.scaler.transform(x.reshape(1, -1))
         elif x.ndim == 2:
-            x = self.scaler.transform( x )
-            
-        # Calculating risk_score, hazard, density and survival 
-        phi      = np.exp( np.dot(x, self.weights) )
-        hazard   = self.baseline_hazard*phi.reshape(-1, 1)
+            x = self.scaler.transform(x)
+
+        # Calculating risk_score, hazard, density and survival
+        phi = np.exp(np.dot(x, self.weights))
+        hazard = self.baseline_hazard * phi.reshape(-1, 1)
         survival = np.power(self.baseline_survival, phi.reshape(-1, 1))
-        density  = hazard*survival
+        density = hazard * survival
         if t is None:
             return hazard, density, survival
         else:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets ]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_index)
             return hazard[:, index], density[:, index], survival[:, index]
 
-
-    def predict_risk(self, x, use_log = False):
+    def predict_risk(self, x, use_log=False):
         """
         Predicting the risk score functions
-        
+
         Arguments:
             * x: pd.Dataframe or np.ndarray or list
                 x is the testing dataset containing the features
                 x should not be standardized before, the model
                 will take care of it
-        """        
+        """
 
-         # Convert x into the right format
+        # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Scaling the dataset
         if x.ndim == 1:
-            x = self.scaler.transform( x.reshape(1, -1) )
+            x = self.scaler.transform(x.reshape(1, -1))
         elif x.ndim == 2:
-            x = self.scaler.transform( x )
-            
+            x = self.scaler.transform(x)
+
         # Calculating risk_score
-        risk_score  = np.exp( np.dot(x, self.weights) )   
+        risk_score = np.exp(np.dot(x, self.weights))
         if not use_log:
             risk_score = np.exp(risk_score)
 
         return risk_score
 
-        
-
 
 class NonLinearCoxPHModel(BaseModel):
-    """ NonLinear Cox Proportional Hazard model (NeuralCoxPH)
-        
-        The original Cox Proportional Hazard model, was first introduced 
-        by  David R Cox in `Regression models and life-tables`.
+    """NonLinear Cox Proportional Hazard model (NeuralCoxPH)
 
-        The NonLinear CoxPH model was popularized by Katzman et al.
-        in `DeepSurv: Personalized Treatment Recommender System Using
-        A Cox Proportional Hazards Deep Neural Network` by allowing the use of 
-        Neural Networks within the original design. 
-        This current adaptation of the model differs from DeepSurv 
-        as it uses the Efron's method to take ties into account.
+    The original Cox Proportional Hazard model, was first introduced
+    by  David R Cox in `Regression models and life-tables`.
 
-        Parameters
-        ----------
-            * structure: None or list of dictionaries
-                Provides an MLP structure within the CoxPH
-                If None, then the model becomes the Linear CoxPH
-                ex: structure = [ {'activation': 'relu', 'num_units': 128}, 
-                                  {'activation': 'tanh', 'num_units': 128}, ] 
-                Here are the possible activation functions:
-                    * Atan
-                    * BentIdentity
-                    * BipolarSigmoid
-                    * CosReLU
-                    * ELU
-                    * Gaussian
-                    * Hardtanh
-                    * Identity
-                    * InverseSqrt
-                    * LeakyReLU
-                    * LeCunTanh
-                    * LogLog
-                    * LogSigmoid
-                    * ReLU
-                    * SELU
-                    * Sigmoid
-                    * Sinc
-                    * SinReLU
-                    * Softmax
-                    * Softplus
-                    * Softsign
-                    * Swish
-                    * Tanh
+    The NonLinear CoxPH model was popularized by Katzman et al.
+    in `DeepSurv: Personalized Treatment Recommender System Using
+    A Cox Proportional Hazards Deep Neural Network` by allowing the use of
+    Neural Networks within the original design.
+    This current adaptation of the model differs from DeepSurv
+    as it uses the Efron's method to take ties into account.
 
-            * auto_scaler: boolean (default=True)
-                Determines whether a sklearn scaler should be automatically 
-                applied             
+    Parameters
+    ----------
+        * structure: None or list of dictionaries
+            Provides an MLP structure within the CoxPH
+            If None, then the model becomes the Linear CoxPH
+            ex: structure = [ {'activation': 'relu', 'num_units': 128},
+                              {'activation': 'tanh', 'num_units': 128}, ]
+            Here are the possible activation functions:
+                * Atan
+                * BentIdentity
+                * BipolarSigmoid
+                * CosReLU
+                * ELU
+                * Gaussian
+                * Hardtanh
+                * Identity
+                * InverseSqrt
+                * LeakyReLU
+                * LeCunTanh
+                * LogLog
+                * LogSigmoid
+                * ReLU
+                * SELU
+                * Sigmoid
+                * Sinc
+                * SinReLU
+                * Softmax
+                * Softplus
+                * Softsign
+                * Swish
+                * Tanh
+
+        * auto_scaler: boolean (default=True)
+            Determines whether a sklearn scaler should be automatically
+            applied
     """
 
-    def __init__(self, structure=None, auto_scaler = True):
-        
+    def __init__(self, structure=None, auto_scaler=True):
         # Saving attributes
         self.structure = structure
         self.loss_values = []
-        
+
         # Initializing the elements from BaseModel
         super(NonLinearCoxPHModel, self).__init__(auto_scaler)
 
-
-
     def risk_fail_matrix(self, T, E):
-        """ Calculating the Risk, Fail matrices to calculate the loss 
-            function by vectorizing all the quantities at stake
+        """Calculating the Risk, Fail matrices to calculate the loss
+        function by vectorizing all the quantities at stake
         """
 
         N = T.shape[0]
-        Risk = np.zeros( (self.nb_times, N) )
-        Fail = np.zeros( (self.nb_times, N) )
-        
-        for i in range(N):
-            
-            # At risk
-            index_risk = np.argwhere( self.times <= T[i] ).flatten()
-            Risk[ index_risk, i] = 1.
-            
-            # Failed
-            if E[i] == 1 :
-                index_fail = np.argwhere( self.times == T[i] )[0]
-                Fail[index_fail, i] = 1.
+        Risk = np.zeros((self.nb_times, N))
+        Fail = np.zeros((self.nb_times, N))
 
-        self.nb_fail_per_time = np.sum( Fail, axis = 1 ).astype(int)
+        for i in range(N):
+            # At risk
+            index_risk = np.argwhere(self.times <= T[i]).flatten()
+            Risk[index_risk, i] = 1.0
+
+            # Failed
+            if E[i] == 1:
+                index_fail = np.argwhere(self.times == T[i])[0]
+                Fail[index_fail, i] = 1.0
+
+        self.nb_fail_per_time = np.sum(Fail, axis=1).astype(int)
         return torch.FloatTensor(Risk), torch.FloatTensor(Fail)
 
-
     def efron_matrix(self):
-        """ Computing the Efron Coefficient matrices to calculate the loss 
-            function by vectorizing all the quantities at stake
+        """Computing the Efron Coefficient matrices to calculate the loss
+        function by vectorizing all the quantities at stake
         """
-        
-        max_nb_fails   = int(max(self.nb_fail_per_time))
-        Efron_coef     = np.zeros( (self.nb_times, max_nb_fails ) )
-        Efron_one      = np.zeros( (self.nb_times, max_nb_fails ) )
-        Efron_anti_one = np.ones(  (self.nb_times, max_nb_fails ) )
-        
-        for i, d in enumerate(self.nb_fail_per_time) :
+
+        max_nb_fails = int(max(self.nb_fail_per_time))
+        Efron_coef = np.zeros((self.nb_times, max_nb_fails))
+        Efron_one = np.zeros((self.nb_times, max_nb_fails))
+        Efron_anti_one = np.ones((self.nb_times, max_nb_fails))
+
+        for i, d in enumerate(self.nb_fail_per_time):
             if d > 0:
-                Efron_coef[i, :d] = [ h*1.0/d for h in range( d )]
-                Efron_one [i, :d] = 1.
-                Efron_anti_one[i, :d] = 0.
-                
+                Efron_coef[i, :d] = [h * 1.0 / d for h in range(d)]
+                Efron_one[i, :d] = 1.0
+                Efron_anti_one[i, :d] = 0.0
+
         Efron_coef = torch.FloatTensor(Efron_coef)
-        Efron_one = torch.FloatTensor(Efron_one)                
-        Efron_anti_one = torch.FloatTensor(Efron_anti_one)        
+        Efron_one = torch.FloatTensor(Efron_one)
+        Efron_anti_one = torch.FloatTensor(Efron_anti_one)
         return Efron_coef, Efron_one, Efron_anti_one
 
-
-    def loss_function(self, model, X, Risk, Fail, 
-                      Efron_coef, Efron_one, Efron_anti_one, l2_reg):
-        """ Efron's approximation loss function by vectorizing 
-            all the quantities at stake
+    def loss_function(self, model, X, Risk, Fail, Efron_coef, Efron_one, Efron_anti_one, l2_reg):
+        """Efron's approximation loss function by vectorizing
+        all the quantities at stake
         """
 
         # Calculating the score
         pre_score = model(X)
-        score = torch.reshape( torch.exp(pre_score), (-1, 1) )
+        score = torch.reshape(torch.exp(pre_score), (-1, 1))
         max_nb_fails = Efron_coef.shape[1]
 
         # Numerator calculation
-        log_score = torch.log( score )
-        log_fail  = torch.mm(Fail, log_score)
-        numerator = torch.sum(log_fail)  
+        log_score = torch.log(score)
+        log_fail = torch.mm(Fail, log_score)
+        numerator = torch.sum(log_fail)
 
         # Denominator calculation
-        risk_score = torch.reshape( torch.mm(Risk, score), (-1,1) )
-        risk_score = risk_score.repeat(1, max_nb_fails)        
-        
-        fail_score = torch.reshape( torch.mm(Fail, score), (-1,1) )
+        risk_score = torch.reshape(torch.mm(Risk, score), (-1, 1))
+        risk_score = risk_score.repeat(1, max_nb_fails)
+
+        fail_score = torch.reshape(torch.mm(Fail, score), (-1, 1))
         fail_score = fail_score.repeat(1, max_nb_fails)
-        
-        Efron_Fail  = fail_score*Efron_coef 
-        Efron_Risk  = risk_score*Efron_one
-        log_efron   = torch.log( Efron_Risk - Efron_Fail + Efron_anti_one)
-                
-        denominator = torch.sum( torch.sum(log_efron, dim=1) )  
-        
+
+        Efron_Fail = fail_score * Efron_coef
+        Efron_Risk = risk_score * Efron_one
+        log_efron = torch.log(Efron_Risk - Efron_Fail + Efron_anti_one)
+
+        denominator = torch.sum(torch.sum(log_efron, dim=1))
+
         # Adding regularization
-        loss = - (numerator - denominator)
+        loss = -(numerator - denominator)
         for w in model.parameters():
-            loss += l2_reg*torch.sum(w*w)/2.
-            
+            loss += l2_reg * torch.sum(w * w) / 2.0
+
         return loss
 
-
-    def fit(self, X, T, E, init_method = 'glorot_uniform',
-            optimizer ='adam', lr = 1e-4, num_epochs = 1000,
-            dropout = 0.2, batch_normalization=False, bn_and_dropout=False,
-            l2_reg=1e-5, verbose=True):
-        """ 
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        init_method="glorot_uniform",
+        optimizer="adam",
+        lr=1e-4,
+        num_epochs=1000,
+        dropout=0.2,
+        batch_normalization=False,
+        bn_and_dropout=False,
+        l2_reg=1e-5,
+        verbose=True,
+    ):
+        """
         Fit the estimator based on the given parameters.
 
         Parameters:
@@ -470,20 +474,20 @@ class NonLinearCoxPHModel(BaseModel):
         * `X` : **array-like**, *shape=(n_samples, n_features)* --
             The input samples.
 
-        * `T` : **array-like** -- 
+        * `T` : **array-like** --
             The target values describing when the event of interest or censoring
             occurred.
 
         * `E` : **array-like** --
-            The values that indicate if the event of interest occurred i.e.: 
-            E[i]=1 corresponds to an event, and E[i] = 0 means censoring, 
+            The values that indicate if the event of interest occurred i.e.:
+            E[i]=1 corresponds to an event, and E[i] = 0 means censoring,
             for all i.
 
-        * `init_method` : **str** *(default = 'glorot_uniform')* -- 
+        * `init_method` : **str** *(default = 'glorot_uniform')* --
             Initialization method to use. Here are the possible options:
 
             * `glorot_uniform`: Glorot/Xavier uniform initializer
-            * `he_uniform`: He uniform variance scaling initializer 
+            * `he_uniform`: He uniform variance scaling initializer
             * `uniform`: Initializing tensors with uniform (-1, 1) distribution
             * `glorot_normal`: Glorot normal initializer,
             * `he_normal`: He normal initializer.
@@ -492,7 +496,7 @@ class NonLinearCoxPHModel(BaseModel):
             * `zeros`: Initializing tensors to 0
             * `orthogonal`: Initializing tensors with a orthogonal matrix,
 
-        * `optimizer`:  **str** *(default = 'adam')* -- 
+        * `optimizer`:  **str** *(default = 'adam')* --
             iterative method for optimizing a differentiable objective function.
             Here are the possible options:
 
@@ -504,28 +508,28 @@ class NonLinearCoxPHModel(BaseModel):
             - `sparseadam`
             - `sgd`
 
-        * `lr`: **float** *(default=1e-4)* -- 
+        * `lr`: **float** *(default=1e-4)* --
             learning rate used in the optimization
 
-        * `num_epochs`: **int** *(default=1000)* -- 
+        * `num_epochs`: **int** *(default=1000)* --
             The number of iterations in the optimization
 
-        * `dropout`: **float** *(default=0.5)* -- 
-            Randomly sets a fraction rate of input units to 0 
+        * `dropout`: **float** *(default=0.5)* --
+            Randomly sets a fraction rate of input units to 0
             at each update during training time, which helps prevent overfitting.
 
-        * `l2_reg`: **float** *(default=1e-4)* -- 
+        * `l2_reg`: **float** *(default=1e-4)* --
             L2 regularization parameter for the model coefficients
 
-        * `batch_normalization`: **bool** *(default=True)* -- 
+        * `batch_normalization`: **bool** *(default=True)* --
             Applying Batch Normalization or not
 
-        * `bn_and_dropout`: **bool** *(default=False)* -- 
+        * `bn_and_dropout`: **bool** *(default=False)* --
             Applying Batch Normalization and Dropout at the same time
 
-        * `verbose`: **bool** *(default=True)* -- 
+        * `verbose`: **bool** *(default=True)* --
             Whether or not producing detailed logging about the modeling
-                
+
 
         Example:
         --------
@@ -543,16 +547,16 @@ class NonLinearCoxPHModel(BaseModel):
 
         #### 2 - Generating the dataset from a nonlinear Weibull parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'weibull',  
+        sim = SimulationModel( survival_distribution = 'weibull',
                                risk_type = 'Gaussian',
-                               censored_parameter = 2.1, 
+                               censored_parameter = 2.1,
                                alpha = 0.1, beta=3.2 )
 
-        # Generating N random samples 
+        # Generating N random samples
         N = 1000
         dataset = sim.generate_data(num_samples = N, num_features=3)
 
-        # Showing a few data-points 
+        # Showing a few data-points
         dataset.head(2)
 
         #### 3 - Creating the modeling dataset
@@ -570,16 +574,16 @@ class NonLinearCoxPHModel(BaseModel):
         E_train, E_test = data_train['event'].values, data_test['event'].values
 
 
-        #### 4 - Creating an instance of the NonLinear CoxPH model and fitting 
+        #### 4 - Creating an instance of the NonLinear CoxPH model and fitting
         # the data.
 
-        # Defining the MLP structure. Here we will build a 1-hidden layer 
+        # Defining the MLP structure. Here we will build a 1-hidden layer
         # with 150 units and `BentIdentity` as its activation function
         structure = [ {'activation': 'BentIdentity', 'num_units': 150},  ]
 
         # Building the model
-        nonlinear_coxph = NonLinearCoxPHModel(structure=structure) 
-        nonlinear_coxph.fit(X_train, T_train, E_train, lr=1e-3, 
+        nonlinear_coxph = NonLinearCoxPHModel(structure=structure)
+        nonlinear_coxph.fit(X_train, T_train, E_train, lr=1e-3,
             init_method='xav_uniform')
 
 
@@ -587,7 +591,7 @@ class NonLinearCoxPHModel(BaseModel):
         c_index = concordance_index(nonlinear_coxph, X_test, T_test, E_test)
         print('C-index: {:.2f}'.format(c_index))
 
-        ibs = integrated_brier_score(nonlinear_coxph, X_test, T_test, E_test, 
+        ibs = integrated_brier_score(nonlinear_coxph, X_test, T_test, E_test,
             t_max=10, figure_size=(20, 6.5) )
 
         """
@@ -598,11 +602,11 @@ class NonLinearCoxPHModel(BaseModel):
         # Extracting data parameters
         N, self.num_vars = X.shape
         input_shape = self.num_vars
-    
-        # Scaling data 
+
+        # Scaling data
         if self.auto_scaler:
-            X_original = self.scaler.fit_transform( X ) 
-            
+            X_original = self.scaler.fit_transform(X)
+
         # Sorting X, T, E in descending order according to T
         order = np.argsort(-T)
         T = T[order]
@@ -613,29 +617,46 @@ class NonLinearCoxPHModel(BaseModel):
         self.get_time_buckets()
 
         # Initializing the model
-        model = nn.NeuralNet(input_shape, 1, self.structure, 
-                             init_method, dropout, batch_normalization, 
-                             bn_and_dropout )
+        model = nn.NeuralNet(
+            input_shape,
+            1,
+            self.structure,
+            init_method,
+            dropout,
+            batch_normalization,
+            bn_and_dropout,
+        )
 
         # Looping through the data to calculate the loss
-        X = torch.FloatTensor(X_original) 
+        X = torch.FloatTensor(X_original)
 
         # Computing the Risk and Fail tensors
         Risk, Fail = self.risk_fail_matrix(T, E)
-        Risk = torch.FloatTensor(Risk) 
-        Fail = torch.FloatTensor(Fail) 
+        Risk = torch.FloatTensor(Risk)
+        Fail = torch.FloatTensor(Fail)
 
         # Computing Efron's matrices
         Efron_coef, Efron_one, Efron_anti_one = self.efron_matrix()
-        Efron_coef = torch.FloatTensor(Efron_coef) 
-        Efron_one = torch.FloatTensor(Efron_one) 
-        Efron_anti_one = torch.FloatTensor(Efron_anti_one) 
+        Efron_coef = torch.FloatTensor(Efron_coef)
+        Efron_one = torch.FloatTensor(Efron_one)
+        Efron_anti_one = torch.FloatTensor(Efron_anti_one)
 
         # Performing order 1 optimization
-        model, loss_values = opt.optimize(self.loss_function, model, optimizer, 
-            lr, num_epochs, verbose, X=X, Risk=Risk, Fail=Fail, 
-            Efron_coef=Efron_coef, Efron_one=Efron_one, 
-            Efron_anti_one=Efron_anti_one, l2_reg=l2_reg)
+        model, loss_values = opt.optimize(
+            self.loss_function,
+            model,
+            optimizer,
+            lr,
+            num_epochs,
+            verbose,
+            X=X,
+            Risk=Risk,
+            Fail=Fail,
+            Efron_coef=Efron_coef,
+            Efron_one=Efron_one,
+            Efron_anti_one=Efron_anti_one,
+            l2_reg=l2_reg,
+        )
 
         # Saving attributes
         self.model = model.eval()
@@ -650,17 +671,16 @@ class NonLinearCoxPHModel(BaseModel):
         baselines = _baseline_functions(score, T, E)
 
         # Saving the Cython attributes in the Python object
-        self.times = np.array( baselines[0] )
-        self.baseline_hazard = np.array( baselines[1] )
-        self.baseline_survival = np.array( baselines[2] )
+        self.times = np.array(baselines[0])
+        self.baseline_hazard = np.array(baselines[1])
+        self.baseline_survival = np.array(baselines[2])
 
         return self
 
-
-    def predict(self, x, t = None):
-        """ 
+    def predict(self, x, t=None):
+        """
         Predicting the hazard, density and survival functions
-        
+
         Arguments:
             * x: pd.Dataframe or np.ndarray or list
                 x is the testing dataset containing the features
@@ -668,53 +688,52 @@ class NonLinearCoxPHModel(BaseModel):
                 will take care of it
             * t: float (default=None)
                 Time at which hazard, density and survival functions
-                should be calculated. If None, the method returns 
-                the functions for all times t. 
+                should be calculated. If None, the method returns
+                the functions for all times t.
         """
-        
+
         # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Scaling the dataset
         if x.ndim == 1:
-            x = self.scaler.transform( x.reshape(1, -1) )
+            x = self.scaler.transform(x.reshape(1, -1))
         elif x.ndim == 2:
-            x = self.scaler.transform( x )
-            
-        # Calculating risk_score, hazard, density and survival 
-        score    = self.model(torch.FloatTensor(x)).data.numpy().flatten()
-        phi      = np.exp( score )
-        hazard   = self.baseline_hazard*phi.reshape(-1, 1)
+            x = self.scaler.transform(x)
+
+        # Calculating risk_score, hazard, density and survival
+        score = self.model(torch.FloatTensor(x)).data.numpy().flatten()
+        phi = np.exp(score)
+        hazard = self.baseline_hazard * phi.reshape(-1, 1)
         survival = np.power(self.baseline_survival, phi.reshape(-1, 1))
-        density  = hazard*survival
+        density = hazard * survival
         if t is None:
             return hazard, density, survival
         else:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets ]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_index)
             return hazard[:, index], density[:, index], survival[:, index]
 
-
-    def predict_risk(self, x, use_log = False):
+    def predict_risk(self, x, use_log=False):
         """
         Predicting the risk score functions
-        
+
         Arguments:
             * x: pd.Dataframe or np.ndarray or list
                 x is the testing dataset containing the features
                 x should not be standardized before, the model
                 will take care of it
-        """        
+        """
 
         # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Scaling the data
         if self.auto_scaler:
             if x.ndim == 1:
-                x = self.scaler.transform( x.reshape(1, -1) )
+                x = self.scaler.transform(x.reshape(1, -1))
             elif x.ndim == 2:
-                x = self.scaler.transform( x )
+                x = self.scaler.transform(x)
         else:
             # Ensuring x has 2 dimensions
             if x.ndim == 1:
@@ -730,30 +749,28 @@ class NonLinearCoxPHModel(BaseModel):
 
         return score
 
-
     def __repr__(self):
-        """ Representing the class object """
+        """Representing the class object"""
 
         if self.structure is None:
             super(NonLinearCoxPHModel, self).__repr__()
             return self.name
-            
+
         else:
             S = len(self.structure)
             self.name = self.__class__.__name__
             empty = len(self.name)
-            self.name += '( '
+            self.name += "( "
             for i, s in enumerate(self.structure):
-                n = 'Layer({}): '.format(i+1)
-                activation = nn.activation_function(s['activation'], 
-                    return_text=True)
-                n += 'activation = {}, '.format( s['activation'] )
-                n += 'num_units = {} '.format( s['num_units'] )
-                
-                if i != S-1:
-                    self.name += n + '; \n'
-                    self.name += empty*' ' + '  '
+                n = "Layer({}): ".format(i + 1)
+                activation = nn.activation_function(s["activation"], return_text=True)
+                n += "activation = {}, ".format(s["activation"])
+                n += "num_units = {} ".format(s["num_units"])
+
+                if i != S - 1:
+                    self.name += n + "; \n"
+                    self.name += empty * " " + "  "
                 else:
                     self.name += n
-            self.name += ')'
+            self.name += ")"
             return self.name

--- a/pysurvival/models/simulations.py
+++ b/pysurvival/models/simulations.py
@@ -1,33 +1,38 @@
 from __future__ import absolute_import
+
+import copy
+import random
+
 import numpy as np
 import pandas as pd
-import random
 import scipy
-import copy
+
 from pysurvival import utils
 from pysurvival.models import BaseModel
+
 # %matplotlib inline
 
 # List of Survival Distributions
-DISTRIBUTIONS = ['Exponential',
-                 'Weibull',
-                 'Gompertz',
-                 'Log-Logistic',
-                 'Log-Normal',]    
+DISTRIBUTIONS = [
+    "Exponential",
+    "Weibull",
+    "Gompertz",
+    "Log-Logistic",
+    "Log-Normal",
+]
 
 # List of risk types
-RISK_TYPES = ['Linear', 'Square',  'Gaussian']    
-
+RISK_TYPES = ["Linear", "Square", "Gaussian"]
 
 
 class SimulationModel(BaseModel):
-    """ 
-    A general framework for simulating right-censored survival data 
-    for proportional hazards models by incorporating 
-        * a baseline hazard function from a known survival distribution, 
-        * a set of covariates. 
-    
-    The framework is based on "Generating Survival Times to Simulate 
+    """
+    A general framework for simulating right-censored survival data
+    for proportional hazards models by incorporating
+        * a baseline hazard function from a known survival distribution,
+        * a set of covariates.
+
+    The framework is based on "Generating Survival Times to Simulate
     Cox Proportional Hazards Models"
     https://www.ncbi.nlm.nih.gov/pubmed/22763916
 
@@ -45,241 +50,237 @@ class SimulationModel(BaseModel):
             - Gompertz
             - Log-Logistic
             - Log-Normal
-        
+
     * risk_type: string (default='linear')
         Defines the type of risk function. The available options are:
             - Linear
             - Square
             - Gaussian
-        
-    * alpha: double (default = 1.) 
+
+    * alpha: double (default = 1.)
          the scale parameter
 
     * beta: double (default = 1.)
          the shape parameter
-         
+
     * bins: int (default=100)
         the number of bins of the time axis
 
     * censored_parameter: double (default = 1.)
          coefficient used to calculate the censored distribution. This
          distribution is a normal such that N(loc=censored_parameter, scale=5)
-         
+
     * risk_parameter: double (default = 1.)
         Scaling coefficient of the risk score such that:
-            - linear: r(x) = exp(<x, W>) 
+            - linear: r(x) = exp(<x, W>)
             - square: r(x) = exp(risk_parameter*(<x, W>)^2)
-            - gaussian: r(x) = exp( exp(-(<x, W>)^2/risk_parameter) )  
-        <.,.> is the dot product                  
+            - gaussian: r(x) = exp( exp(-(<x, W>)^2/risk_parameter) )
+        <.,.> is the dot product
     """
 
-    def __init__(self, survival_distribution = 'exponential',  
-        risk_type = 'linear', censored_parameter = 1., alpha = 1, beta = 1.,
-        bins = 100, risk_parameter = 1.):
-        
+    def __init__(
+        self,
+        survival_distribution="exponential",
+        risk_type="linear",
+        censored_parameter=1.0,
+        alpha=1,
+        beta=1.0,
+        bins=100,
+        risk_parameter=1.0,
+    ):
         # Saving the attributes
         self.censored_parameter = censored_parameter
-        self.alpha              = alpha 
-        self.beta               = beta
-        self.risk_parameter     = risk_parameter
-        self.bins               = bins
+        self.alpha = alpha
+        self.beta = beta
+        self.risk_parameter = risk_parameter
+        self.bins = bins
         self.features = []
-        
+
         # Checking risk_type
-        if any([risk_type.lower() == r.lower() for r in RISK_TYPES ]):
-            self.risk_type   = risk_type
+        if any([risk_type.lower() == r.lower() for r in RISK_TYPES]):
+            self.risk_type = risk_type
         else:
             error = "{} isn't a valid risk type. "
             error += "Only {} are currently available."
             error = error.format(risk_type, ", ".join(RISK_TYPES))
             raise NotImplementedError(error)
-        
+
         # Checking distribution
-        if any([survival_distribution.lower() == d.lower() \
-                for d in DISTRIBUTIONS ]):
-            self.survival_distribution   = survival_distribution
+        if any([survival_distribution.lower() == d.lower() for d in DISTRIBUTIONS]):
+            self.survival_distribution = survival_distribution
         else:
             error = "{} isn't a valid survival distribution. "
             error += "Only {} are currently available."
-            error = error.format(survival_distribution,", ".join(DISTRIBUTIONS))
+            error = error.format(survival_distribution, ", ".join(DISTRIBUTIONS))
             raise NotImplementedError(error)
-        
+
         # Initializing the elements from BaseModel
-        super(SimulationModel, self).__init__(auto_scaler = True)
-        
+        super(SimulationModel, self).__init__(auto_scaler=True)
 
     @staticmethod
     def random_data(N):
-        """ 
-        Generating a array of size N from a random distribution -- the available 
+        """
+        Generating a array of size N from a random distribution -- the available
         distributions are:
             * binomial,
             * chisquare,
-            * exponential, 
-            * gamma, 
-            * normal, 
-            * uniform 
-            * laplace 
+            * exponential,
+            * gamma,
+            * normal,
+            * uniform
+            * laplace
         """
 
-        index = np.random.binomial(n = 4, p = 0.5)
+        index = np.random.binomial(n=4, p=0.5)
         distributions = {
-            'binomial_a': np.random.binomial(n = 20, p = 0.6, size = N ), 
-            'binomial_b': np.random.binomial(n = 200, p = 0.6, size = N ), 
-            'chisquare': np.random.chisquare(df = 10, size = N ), 
-            'exponential_a': np.random.exponential(scale=0.1, size = N ),
-            'exponential_b': np.random.exponential(scale=0.01, size = N ),
-            'gamma': np.random.gamma(shape=2., scale=2., size = N ),
-            'normal_a': np.random.normal(loc=-1.0, scale=5.0, size=N ),
-            'normal_b': np.random.normal(loc=10.0, scale=10.0, size=N ),
-            'uniform_a': np.random.uniform(low=-2.0, high=10.0, size=N ),
-            'uniform_b': np.random.uniform(low=-20.0, high=100.0, size=N ),
-            'laplace': np.random.laplace(loc=0.0, scale=1.0, size=N )
-            }
+            "binomial_a": np.random.binomial(n=20, p=0.6, size=N),
+            "binomial_b": np.random.binomial(n=200, p=0.6, size=N),
+            "chisquare": np.random.chisquare(df=10, size=N),
+            "exponential_a": np.random.exponential(scale=0.1, size=N),
+            "exponential_b": np.random.exponential(scale=0.01, size=N),
+            "gamma": np.random.gamma(shape=2.0, scale=2.0, size=N),
+            "normal_a": np.random.normal(loc=-1.0, scale=5.0, size=N),
+            "normal_b": np.random.normal(loc=10.0, scale=10.0, size=N),
+            "uniform_a": np.random.uniform(low=-2.0, high=10.0, size=N),
+            "uniform_b": np.random.uniform(low=-20.0, high=100.0, size=N),
+            "laplace": np.random.laplace(loc=0.0, scale=1.0, size=N),
+        }
 
         list_distributions = copy.deepcopy(list(distributions.keys()))
         random.shuffle(list_distributions)
-        key = list_distributions[ index ]
+        key = list_distributions[index]
         return key, distributions[key]
 
-
     def time_function(self, BX):
-        """ 
+        """
         Calculating the survival times based on the given distribution
         T = H^(-1)( -log(U)/risk_score ), where:
-            * H is the cumulative baseline hazard function 
+            * H is the cumulative baseline hazard function
                 (H^(-1) is the inverse function)
             * U is a random variable uniform - Uni[0,1].
 
         The method is inspired by https://gist.github.com/jcrudy/10481743
         """
-        
+
         # Calculating scale coefficient using the features
         num_samples = BX.shape[0]
-        lambda_exp_BX = np.exp(BX)*self.alpha
+        lambda_exp_BX = np.exp(BX) * self.alpha
         lambda_exp_BX = lambda_exp_BX.flatten()
-        
+
         # Generating random uniform variables
         U = np.random.uniform(0, 1, num_samples)
 
-        # Exponential 
-        if self.survival_distribution.lower().startswith('exp') :
-            self.survival_distribution = 'Exponential'
-            return - np.log( U )/( lambda_exp_BX )
+        # Exponential
+        if self.survival_distribution.lower().startswith("exp"):
+            self.survival_distribution = "Exponential"
+            return -np.log(U) / (lambda_exp_BX)
 
-        # Weibull 
-        elif self.survival_distribution.lower().startswith('wei') :
-            self.survival_distribution = 'Weibull'
-            return np.power( - np.log( U )/( lambda_exp_BX ), 1./self.beta )
+        # Weibull
+        elif self.survival_distribution.lower().startswith("wei"):
+            self.survival_distribution = "Weibull"
+            return np.power(-np.log(U) / (lambda_exp_BX), 1.0 / self.beta)
 
-        # Gompertz 
-        elif self.survival_distribution.lower().startswith('gom') :
-            self.survival_distribution = 'Gompertz'
-            return  ( 1./self.beta)*\
-                    np.log( 1 - self.beta*np.log( U )/(lambda_exp_BX) )
+        # Gompertz
+        elif self.survival_distribution.lower().startswith("gom"):
+            self.survival_distribution = "Gompertz"
+            return (1.0 / self.beta) * np.log(1 - self.beta * np.log(U) / (lambda_exp_BX))
 
-        # Log-Logistic 
-        elif 'logistic' in self.survival_distribution.lower() :
-            self.survival_distribution = 'Log-Logistic'
-            return  np.power( U/(1.-U), 1./self.beta )/(lambda_exp_BX )
+        # Log-Logistic
+        elif "logistic" in self.survival_distribution.lower():
+            self.survival_distribution = "Log-Logistic"
+            return np.power(U / (1.0 - U), 1.0 / self.beta) / (lambda_exp_BX)
 
         # Log-Normal
-        elif 'normal' in self.survival_distribution.lower() :
-            self.survival_distribution = 'Log-Normal'
+        elif "normal" in self.survival_distribution.lower():
+            self.survival_distribution = "Log-Normal"
             W = np.random.normal(0, 1, num_samples)
-            return  lambda_exp_BX*np.exp(self.beta*W)
+            return lambda_exp_BX * np.exp(self.beta * W)
 
-    
     def hazard_function(self, t, BX):
-        """ Calculating the hazard function based on the given distribution """
-        
+        """Calculating the hazard function based on the given distribution"""
+
         # Calculating scale coefficient using the features
-        _lambda = self.alpha*np.exp( BX )
+        _lambda = self.alpha * np.exp(BX)
 
-        # Exponential 
-        if self.survival_distribution.lower().startswith( 'exp' ) : 
-            return  np.repeat(_lambda, len(t)) 
+        # Exponential
+        if self.survival_distribution.lower().startswith("exp"):
+            return np.repeat(_lambda, len(t))
 
-        # Weibull 
-        elif self.survival_distribution.lower().startswith('wei'):
-            return  _lambda*self.beta*np.power( t, self.beta-1 ) 
+        # Weibull
+        elif self.survival_distribution.lower().startswith("wei"):
+            return _lambda * self.beta * np.power(t, self.beta - 1)
 
-        # Gompertz 
-        elif self.survival_distribution.lower().startswith('gom'):
-            return  _lambda*np.exp(self.beta*t )
+        # Gompertz
+        elif self.survival_distribution.lower().startswith("gom"):
+            return _lambda * np.exp(self.beta * t)
 
-        # Log-Logistic 
-        elif self.survival_distribution.lower().endswith('logistic'):
-            numerator =  _lambda*self.beta*np.power((_lambda*t), self.beta-1 )
-            denominator =  (1 + np.power( (_lambda*t), self.beta) )
-            return numerator/denominator
-    
+        # Log-Logistic
+        elif self.survival_distribution.lower().endswith("logistic"):
+            numerator = _lambda * self.beta * np.power((_lambda * t), self.beta - 1)
+            denominator = 1 + np.power((_lambda * t), self.beta)
+            return numerator / denominator
+
         # Log-Normal
-        elif self.survival_distribution.lower().endswith('normal'):
-            arg_normal = (np.log(t) - np.log(_lambda))/self.beta
-            numerator   =  (1./(t*self.beta))*scipy.stats.norm.pdf( arg_normal )
-            denominator =  1. - scipy.stats.norm.cdf(arg_normal)
-            return numerator/denominator
+        elif self.survival_distribution.lower().endswith("normal"):
+            arg_normal = (np.log(t) - np.log(_lambda)) / self.beta
+            numerator = (1.0 / (t * self.beta)) * scipy.stats.norm.pdf(arg_normal)
+            denominator = 1.0 - scipy.stats.norm.cdf(arg_normal)
+            return numerator / denominator
 
-    
     def survival_function(self, t, BX):
-        """ 
-        Calculating the survival function based on the given 
-        distribution 
+        """
+        Calculating the survival function based on the given
+        distribution
         """
 
         # Calculating scale coefficient using the features
-        _lambda = self.alpha*np.exp( BX )
+        _lambda = self.alpha * np.exp(BX)
 
-        # Exponential 
-        if self.survival_distribution.lower().startswith( 'exp' ) :
-            return np.exp( -t*_lambda )
+        # Exponential
+        if self.survival_distribution.lower().startswith("exp"):
+            return np.exp(-t * _lambda)
 
-        # Weibull 
-        elif self.survival_distribution.lower().startswith('wei'):
-            return np.exp( -np.power(t, self.beta)*_lambda )
+        # Weibull
+        elif self.survival_distribution.lower().startswith("wei"):
+            return np.exp(-np.power(t, self.beta) * _lambda)
 
-        # Gompertz 
-        elif self.survival_distribution.lower().startswith('gom'):
-            return np.exp( -_lambda/self.beta*( np.exp(self.beta*t) - 1) )
+        # Gompertz
+        elif self.survival_distribution.lower().startswith("gom"):
+            return np.exp(-_lambda / self.beta * (np.exp(self.beta * t) - 1))
 
-        # Log-Logistic 
-        elif self.survival_distribution.lower().endswith('logistic'):
-            return 1./(1.+ np.power(_lambda*t, self.beta) )
+        # Log-Logistic
+        elif self.survival_distribution.lower().endswith("logistic"):
+            return 1.0 / (1.0 + np.power(_lambda * t, self.beta))
 
         # Log-Normal
-        elif self.survival_distribution.lower().endswith('normal'):
-            arg_cdf = (np.log(t) - np.log(_lambda))/self.beta
-            return 1. - scipy.stats.norm.cdf(arg_cdf)
-
+        elif self.survival_distribution.lower().endswith("normal"):
+            arg_cdf = (np.log(t) - np.log(_lambda)) / self.beta
+            return 1.0 - scipy.stats.norm.cdf(arg_cdf)
 
     def risk_function(self, x_std):
-        """ Calculating the risk function based on the given risk type """
-        
+        """Calculating the risk function based on the given risk type"""
+
         # Dot product
-        risk = np.dot( x_std, self.feature_weights )
-        
+        risk = np.dot(x_std, self.feature_weights)
+
         # Choosing the type of risk
-        if self.risk_type.lower() == 'linear' :
+        if self.risk_type.lower() == "linear":
             return risk.reshape(-1, 1)
 
-        elif self.risk_type.lower() == 'square' :
-            risk = np.square(risk*self.risk_parameter)
+        elif self.risk_type.lower() == "square":
+            risk = np.square(risk * self.risk_parameter)
 
-
-        elif self.risk_type.lower() == 'gaussian' :
+        elif self.risk_type.lower() == "gaussian":
             risk = np.square(risk)
-            risk = np.exp( - risk*self.risk_parameter)
+            risk = np.exp(-risk * self.risk_parameter)
 
         return risk.reshape(-1, 1)
 
-        
-    def generate_data(self, num_samples = 100, num_features = 3, 
-        feature_weights = None):
-        """ 
-        Generating a dataset of simulated survival times from a given 
-        distribution through the hazard function using the Cox model  
-        
+    def generate_data(self, num_samples=100, num_features=3, feature_weights=None):
+        """
+        Generating a dataset of simulated survival times from a given
+        distribution through the hazard function using the Cox model
+
         Parameters:
         -----------
         * `num_samples`: **int** *(default=100)* --
@@ -288,9 +289,9 @@ class SimulationModel(BaseModel):
         * `num_features`: **int** *(default=3)* --
             Number of features to generate
 
-        * `feature_weights`: **array-like** *(default=None)* -- 
-            list of the coefficients of the underlying Cox-Model. 
-            The features linked to each coefficient are generated 
+        * `feature_weights`: **array-like** *(default=None)* --
+            list of the coefficients of the underlying Cox-Model.
+            The features linked to each coefficient are generated
             from random distribution from the following list:
 
             * binomial
@@ -314,10 +315,10 @@ class SimulationModel(BaseModel):
         from pysurvival.models.simulations import SimulationModel
 
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'gompertz',  
+        sim = SimulationModel( survival_distribution = 'gompertz',
                                risk_type = 'linear',
-                               censored_parameter = 5.0, 
-                               alpha = 0.01, 
+                               censored_parameter = 5.0,
+                               alpha = 0.01,
                                beta = 5., )
 
         # Generating N Random samples
@@ -327,11 +328,11 @@ class SimulationModel(BaseModel):
         # Showing a few data-points
         dataset.head()
         """
-        
+
         # Data parameters
         self.num_variables = num_features
-        if feature_weights is None :
-            self.feature_weights = [1.]*self.num_variables
+        if feature_weights is None:
+            self.feature_weights = [1.0] * self.num_variables
             feature_weights = self.feature_weights
 
         else:
@@ -347,44 +348,41 @@ class SimulationModel(BaseModel):
         # Creating the features
         X = np.zeros((num_samples, self.num_variables))
         columns = []
-        for i in range( self.num_variables ) :
+        for i in range(self.num_variables):
             key, X[:, i] = self.random_data(num_samples)
-            columns.append( 'x_' + str(i+1) )
-        X_std = self.scaler.fit_transform( X )
-        BX = self.risk_function( X_std )
-        
+            columns.append("x_" + str(i + 1))
+        X_std = self.scaler.fit_transform(X)
+        BX = self.risk_function(X_std)
+
         # Building the survival times
-        T = self.time_function(BX) 
-        C = np.random.normal( loc = self.censored_parameter,
-            scale = 5, size = num_samples )
-        C = np.maximum(C, 0.)
-        time = np.minimum( T, C )
-        E = 1.*(T == time)
+        T = self.time_function(BX)
+        C = np.random.normal(loc=self.censored_parameter, scale=5, size=num_samples)
+        C = np.maximum(C, 0.0)
+        time = np.minimum(T, C)
+        E = 1.0 * (T == time)
 
         # Building dataset
         self.features = columns
-        self.dataset = pd.DataFrame( data = np.c_[X, time, E], 
-                                     columns = columns + ['time', 'event'] )
-        
+        self.dataset = pd.DataFrame(data=np.c_[X, time, E], columns=columns + ["time", "event"])
+
         # Building the time axis and time buckets
-        self.times = np.linspace(0., max(self.dataset['time']), self.bins)
+        self.times = np.linspace(0.0, max(self.dataset["time"]), self.bins)
         self.get_time_buckets()
-        
+
         # Building baseline functions
-        self.baseline_hazard   =  self.hazard_function(self.times, 0)
-        self.baseline_survival =  self.survival_function(self.times, 0) 
+        self.baseline_hazard = self.hazard_function(self.times, 0)
+        self.baseline_survival = self.survival_function(self.times, 0)
 
         # Printing summary message
         message_to_print = "Number of data-points: {} - Number of events: {}"
-        print( message_to_print.format(num_samples, sum(E)) )
+        print(message_to_print.format(num_samples, sum(E)))
 
         return self.dataset
-    
-    
-    def predict(self, x, t = None):
-        """ 
+
+    def predict(self, x, t=None):
+        """
         Predicting the hazard, density and survival functions
-        
+
         Parameters:
         -----------
             * x: pd.Dataframe or np.ndarray or list
@@ -393,68 +391,66 @@ class SimulationModel(BaseModel):
                 will take care of it
             * t: float (default=None)
                 Time at which hazard, density and survival functions
-                should be calculated. If None, the method returns 
-                the functions for all times t. 
+                should be calculated. If None, the method returns
+                the functions for all times t.
         """
 
         # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Scaling the dataset
         if x.ndim == 1:
-            x = self.scaler.transform( x.reshape(1, -1) )
+            x = self.scaler.transform(x.reshape(1, -1))
 
         elif x.ndim == 2:
-            x = self.scaler.transform( x )
+            x = self.scaler.transform(x)
 
         else:
             # Ensuring x has 2 dimensions
             if x.ndim == 1:
                 x = np.reshape(x, (1, -1))
 
-        # Calculating risk_score, hazard, density and survival 
-        BX = self.risk_function(x) 
-        hazard   = self.hazard_function(self.times, BX.reshape(-1, 1))
+        # Calculating risk_score, hazard, density and survival
+        BX = self.risk_function(x)
+        hazard = self.hazard_function(self.times, BX.reshape(-1, 1))
         survival = self.survival_function(self.times, BX.reshape(-1, 1))
-        density  = (hazard*survival)
-        
+        density = hazard * survival
+
         if t is None:
             return hazard, density, survival
         else:
-            min_abs_value = [abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets]
+            min_abs_value = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_abs_value)
             return hazard[:, index], density[:, index], survival[:, index]
-
 
     def predict_risk(self, x):
         """
         Predicting the risk score function
-        
+
         Parameters:
         -----------
             * x: pd.Dataframe or np.ndarray or list
                 x is the testing dataset containing the features
                 x should not be standardized before, the model
                 will take care of it
-        """        
+        """
 
         # Convert x into the right format
         x = utils.check_data(x)
-        
+
         # Scaling the dataset
         if x.ndim == 1:
-            x = self.scaler.transform( x.reshape(1, -1) )
+            x = self.scaler.transform(x.reshape(1, -1))
 
         elif x.ndim == 2:
-            x = self.scaler.transform( x )
+            x = self.scaler.transform(x)
 
         else:
             # Ensuring x has 2 dimensions
             if x.ndim == 1:
                 x = np.reshape(x, (1, -1))
-            
+
         # Calculating risk_score
-        risk_score  = self.risk_function(x) 
+        risk_score = self.risk_function(x)
 
         return risk_score
-

--- a/pysurvival/models/survival_forest.py
+++ b/pysurvival/models/survival_forest.py
@@ -1,18 +1,18 @@
 from __future__ import absolute_import
+
+import os
 import warnings
+
 import numpy as np
 import pandas as pd
-import os
-import copy
-from sklearn.preprocessing import StandardScaler
-from pysurvival import utils
+
+from pysurvival import PYTHON_VERSION, utils
 from pysurvival.models import BaseModel
 from pysurvival.models._survival_forest import _SurvivalForestModel
-from pysurvival import PYTHON_VERSION
-
 
 # Available Splitting
-SPLITTING_RULES = { 'logrank': 1, 'maxstat': 4, 'extratrees':5}
+SPLITTING_RULES = {"logrank": 1, "maxstat": 4, "extratrees": 5}
+
 
 class BaseSurvivalForest(BaseModel):
     """
@@ -25,21 +25,20 @@ class BaseSurvivalForest(BaseModel):
         The number of trees in the forest.
 
     * splitrule: int (default=0)
-        Splitting rule used to build trees:  
+        Splitting rule used to build trees:
             - 1, "logrank" yields the RandomSurvivalForest
             - 4, "maxstat" yields the ConditionalSurvivalForest
             - 5, "extratrees" yields the ExtraSurvivalTrees
 
     """
 
-    def __init__(self, splitrule = "Logrank", num_trees = 10):
-
+    def __init__(self, splitrule="Logrank", num_trees=10):
         # Checking the format of num_trees
-        if not ( isinstance(num_trees, int) or isinstance(num_trees, float) ):
+        if not (isinstance(num_trees, int) or isinstance(num_trees, float)):
             error = '{} is not a valid value for "num_trees" '
             error += 'as "num_trees" is a positive integer'.format(num_trees)
             raise ValueError(error)
-        if num_trees <= 0 :
+        if num_trees <= 0:
             error = '{} is not a valid value for "num_trees" '
             error += 'as "num_trees" is a positive integer'.format(num_trees)
             raise ValueError(error)
@@ -47,7 +46,7 @@ class BaseSurvivalForest(BaseModel):
 
         # Checking the format of splitrule
         if SPLITTING_RULES.get(splitrule.lower()) is None:
-            error = '{} is not a valid splitrule method. Choose between '
+            error = "{} is not a valid splitrule method. Choose between "
             error += '"' + '", "'.join(SPLITTING_RULES) + '"'
             error = error.format(splitrule)
             raise ValueError(error)
@@ -57,38 +56,36 @@ class BaseSurvivalForest(BaseModel):
         self.model = _SurvivalForestModel()
 
         # Initializing the elements from BaseModel
-        super(BaseSurvivalForest, self).__init__(auto_scaler = False)
-
+        super(BaseSurvivalForest, self).__init__(auto_scaler=False)
 
     def save(self, path_file):
-        """ Save the model parameters of the model and compress them into 
-            a zip file
+        """Save the model parameters of the model and compress them into
+        a zip file
         """
 
         # Ensuring the file has the proper name
-        folder_name = os.path.dirname(path_file) + '/'
+        folder_name = os.path.dirname(path_file) + "/"
         file_name = os.path.basename(path_file)
 
         # Checking if the folder is accessible
         if not os.access(folder_name, os.W_OK):
-            error_msg = '{} is not an accessible directory.'.format(folder_name)
+            error_msg = "{} is not an accessible directory.".format(folder_name)
             raise OSError(error_msg)
 
         # Delete the C++ object before saving
         del self.model
-        
+
         # Saving the model
         super(BaseSurvivalForest, self).save(path_file)
 
         # Re-introduce the C++ object
         self.model = _SurvivalForestModel()
         self.load_properties()
-        
 
     def load(self, path_file):
-        """ Load the model parameters from a zip file into a C++ external
-            model 
-        """   
+        """Load the model parameters from a zip file into a C++ external
+        model
+        """
 
         # Loading the model
         super(BaseSurvivalForest, self).load(path_file)
@@ -97,23 +94,35 @@ class BaseSurvivalForest(BaseModel):
         self.model = _SurvivalForestModel()
         self.load_properties()
 
-
-    def fit(self, X, T, E, max_features = 'sqrt', max_depth = 5, 
-            min_node_size = 10, num_threads = -1, weights = None, 
-            sample_size_pct = 0.63, alpha = 0.5, minprop=0.1,
-            num_random_splits = 100, importance_mode = 'impurity_corrected', 
-            seed = None, save_memory=False ):
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        max_features="sqrt",
+        max_depth=5,
+        min_node_size=10,
+        num_threads=-1,
+        weights=None,
+        sample_size_pct=0.63,
+        alpha=0.5,
+        minprop=0.1,
+        num_random_splits=100,
+        importance_mode="impurity_corrected",
+        seed=None,
+        save_memory=False,
+    ):
         """
         Arguments:
         ---------
         * X : array-like, shape=(n_samples, n_features)
             The input samples.
 
-        * T : array-like, shape = [n_samples] 
+        * T : array-like, shape = [n_samples]
             The target values describing when the event of interest or censoring
             occurred
 
-        * E : array-like, shape = [n_samples] 
+        * E : array-like, shape = [n_samples]
             The Event indicator array such that E = 1. if the event occurred
             E = 0. if censoring occurred
 
@@ -123,19 +132,19 @@ class BaseSurvivalForest(BaseModel):
             - If float, then `max_features` is a fraction and
               `int(max_features * n_features)` features are considered at each
               split.
-            - If "sqrt", then `max_features=sqrt(n_features)` 
+            - If "sqrt", then `max_features=sqrt(n_features)`
             - If "log2", then `max_features=log2(n_features)`.
 
         * min_node_size : int(default=10)
             The minimum number of samples required to be at a leaf node
 
         * num_threads: int (Default: -1)
-            The number of jobs to run in parallel for both fit and predict. 
+            The number of jobs to run in parallel for both fit and predict.
             If -1, then the number of jobs is set to the number of cores.
 
         * weights: array-like, shape = [n_samples] (default=None)
-            Weights for sampling of training observations. 
-            Observations with larger weights will be selected with 
+            Weights for sampling of training observations.
+            Observations with larger weights will be selected with
             higher probability in the bootstrap
 
         * sample_size_pct: double (default = 0.63)
@@ -145,28 +154,28 @@ class BaseSurvivalForest(BaseModel):
             For "maxstat" splitrule: Significance threshold to allow splitting.
 
         * minprop: float
-            For "maxstat" splitrule: Lower quantile of covariate 
+            For "maxstat" splitrule: Lower quantile of covariate
             distribution to be considered for splitting.
 
         * num_random_splits: int (default=100)
-            For "extratrees" splitrule, it is the Number of random splits 
+            For "extratrees" splitrule, it is the Number of random splits
             to consider for each candidate splitting variable.
 
         * importance_mode:  (default=impurity_corrected)
             Variable importance mode. Here are the 2 options:
-            - `impurity` or `impurity_corrected`: 
-                it's the unbiased heterogeneity reduction developed 
+            - `impurity` or `impurity_corrected`:
+                it's the unbiased heterogeneity reduction developed
                 by Sandri & Zuccolotto (2008)
             - "permutation" it's unnormalized as recommended by Nicodemus et al.
-            - "normalized_permutation" it's normalized version of the 
+            - "normalized_permutation" it's normalized version of the
                 permutation importance computations by Breiman et al.
 
-        * `seed`: int (default=None) -- 
-            seed used by the random number generator. If None, the current 
+        * `seed`: int (default=None) --
+            seed used by the random number generator. If None, the current
             timestamp converted in UNIX is used.
 
         * save_memory:  bool (default=False) --
-            Use memory saving splitting mode. This will slow down the model 
+            Use memory saving splitting mode. This will slow down the model
             training. So, only set to `True` if you encounter memory problems.
 
 
@@ -186,16 +195,16 @@ class BaseSurvivalForest(BaseModel):
 
         #### 2 - Generating the dataset from a Exponential parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'exponential',  
+        sim = SimulationModel( survival_distribution = 'exponential',
                                risk_type = 'linear',
-                               censored_parameter = 1, 
+                               censored_parameter = 1,
                                alpha = 3)
 
-        # Generating N random samples 
+        # Generating N random samples
         N = 1000
         dataset = sim.generate_data(num_samples = N, num_features=4)
 
-        # Showing a few data-points 
+        # Showing a few data-points
         dataset.head(2)
 
         #### 3 - Creating the modeling dataset
@@ -215,8 +224,8 @@ class BaseSurvivalForest(BaseModel):
 
         #### 4 - Creating an instance of the model and fitting the data.
         # Building the model
-        csf = ConditionalSurvivalForestModel(num_trees=200) 
-        csf.fit(X_train, T_train, E_train, 
+        csf = ConditionalSurvivalForestModel(num_trees=200)
+        csf.fit(X_train, T_train, E_train,
                 max_features="sqrt", max_depth=5, min_node_size=20,
                 alpha = 0.05, minprop=0.1)
 
@@ -225,7 +234,7 @@ class BaseSurvivalForest(BaseModel):
         c_index = concordance_index(l_mtlr, X_test, T_test, E_test) #0.81
         print('C-index: {:.2f}'.format(c_index))
 
-        ibs = integrated_brier_score(l_mtlr, X_test, T_test, E_test, t_max=30, 
+        ibs = integrated_brier_score(l_mtlr, X_test, T_test, E_test, t_max=30,
                     figure_size=(20, 6.5) )
         """
 
@@ -234,19 +243,18 @@ class BaseSurvivalForest(BaseModel):
         if isinstance(X, pd.DataFrame):
             features = X.columns.tolist()
         else:
-            features = ['x_{}'.format(i) for i in range(self.num_variables)]
+            features = ["x_{}".format(i) for i in range(self.num_variables)]
         all_data_features = ["time", "event"] + features
 
         # Transforming the strings into bytes
-        all_data_features = utils.as_bytes(all_data_features, 
-            python_version=PYTHON_VERSION)
+        all_data_features = utils.as_bytes(all_data_features, python_version=PYTHON_VERSION)
 
-        # Checking the format of the data 
+        # Checking the format of the data
         X, T, E = utils.check_data(X, T, E)
         if X.ndim == 1:
-            X = X.reshape(1,-1)
-            T = T.reshape(1,-1)
-            E = E.reshape(1,-1)
+            X = X.reshape(1, -1)
+            T = T.reshape(1, -1)
+            E = E.reshape(1, -1)
         input_data = np.c_[T, E, X]
 
         # Number of trees
@@ -257,18 +265,18 @@ class BaseSurvivalForest(BaseModel):
             seed = 0
 
         # sample_size_pct
-        if not isinstance(sample_size_pct, float): 
+        if not isinstance(sample_size_pct, float):
             error = "Error: Invalid value for sample_size_pct, "
             error += "please provide a value that is > 0 and <= 1."
-            raise ValueError(error) 
+            raise ValueError(error)
 
-        if (sample_size_pct <= 0 or sample_size_pct > 1) :
+        if sample_size_pct <= 0 or sample_size_pct > 1:
             error = "Error: Invalid value for sample_size_pct, "
             error += "please provide a value that is > 0 and <= 1."
-            raise ValueError(error)        
+            raise ValueError(error)
 
         # Split Rule
-        if self.splitrule.lower() == 'logrank':
+        if self.splitrule.lower() == "logrank":
             split_mode = 1
             alpha = 0
             minprop = 0
@@ -279,27 +287,27 @@ class BaseSurvivalForest(BaseModel):
             num_random_splits = 1
 
             # Maxstat splitting
-            if not isinstance(alpha, float): 
+            if not isinstance(alpha, float):
                 error = "Error: Invalid value for alpha, "
                 error += "please provide a value that is > 0 and < 1."
-                raise ValueError(error) 
+                raise ValueError(error)
 
-            if (alpha <= 0 or alpha >= 1) :
+            if alpha <= 0 or alpha >= 1:
                 error = "Error: Invalid value for alpha, "
                 error += "please provide a value between 0 and 1."
                 raise ValueError(error)
 
-            if not isinstance(minprop, float): 
+            if not isinstance(minprop, float):
                 error = "Error: Invalid value for minprop, "
                 error += "please provide a value between 0 and 0.5"
-                raise ValueError(error)    
+                raise ValueError(error)
 
-            if (minprop < 0 or minprop > 0.5) :
+            if minprop < 0 or minprop > 0.5:
                 error = "Error: Invalid value for minprop, "
                 error += "please provide a value between 0 and 0.5"
-                raise ValueError(error)             
+                raise ValueError(error)
 
-        elif self.splitrule.lower() == 'extratrees':
+        elif self.splitrule.lower() == "extratrees":
             split_mode = 5
             alpha = 0
             minprop = 0
@@ -307,24 +315,21 @@ class BaseSurvivalForest(BaseModel):
         # Number of variables to possibly split at in each node
         self.max_features = max_features
         if isinstance(self.max_features, str):
+            if self.max_features.lower() == "sqrt":
+                num_variables_to_use = int(np.sqrt(self.num_variables))
 
-            if self.max_features.lower() == 'sqrt':
-                num_variables_to_use = int( np.sqrt(self.num_variables) )
+            elif "log" in self.max_features.lower():
+                num_variables_to_use = int(np.log(self.num_variables))
 
-            elif 'log' in self.max_features.lower() :
-                num_variables_to_use = int( np.log(self.num_variables) )
-
-            elif self.max_features.lower() == 'all':
+            elif self.max_features.lower() == "all":
                 num_variables_to_use = self.num_variables
 
             else:
                 raise ValueError("Unknown max features option")
 
-        elif isinstance(self.max_features, float) or \
-            isinstance(self.max_features, int):
-
+        elif isinstance(self.max_features, float) or isinstance(self.max_features, int):
             if 0 < self.max_features < 1:
-                num_variables_to_use = int(self.num_variables*self.max_features)
+                num_variables_to_use = int(self.num_variables * self.max_features)
 
             elif self.max_features >= 1:
                 num_variables_to_use = min(self.num_variables, self.max_features)
@@ -342,15 +347,13 @@ class BaseSurvivalForest(BaseModel):
             raise ValueError("Unknown max features option")
 
         # Defining importance mode
-        if 'permutation' in importance_mode.lower() :
-
-            if 'scaled' in importance_mode.lower() or \
-            'normalized' in importance_mode.lower():
+        if "permutation" in importance_mode.lower():
+            if "scaled" in importance_mode.lower() or "normalized" in importance_mode.lower():
                 importance_mode = 2
             else:
                 importance_mode = 3
 
-        elif 'impurity' in importance_mode.lower() :
+        elif "impurity" in importance_mode.lower():
             importance_mode = 5
 
         else:
@@ -359,11 +362,11 @@ class BaseSurvivalForest(BaseModel):
 
         # Weights
         if weights is None:
-            case_weights = [1./N]*N
+            case_weights = [1.0 / N] * N
         else:
             case_weights = utils.check_data(weights)
 
-            if abs(sum(case_weights) - 1.) >= 1e-4:
+            if abs(sum(case_weights) - 1.0) >= 1e-4:
                 raise Exception("The sum of the weights needs to be equal to 1.")
 
             if len(case_weights) != N:
@@ -371,11 +374,25 @@ class BaseSurvivalForest(BaseModel):
 
         # Fitting the model using the C++ object
         verbose = True
-        self.model.fit( input_data, all_data_features, case_weights,
-                num_trees, num_variables_to_use, min_node_size, max_depth,
-                alpha, minprop, num_random_splits, sample_size_pct, 
-                importance_mode, split_mode, verbose, seed, num_threads, 
-                save_memory)
+        self.model.fit(
+            input_data,
+            all_data_features,
+            case_weights,
+            num_trees,
+            num_variables_to_use,
+            min_node_size,
+            max_depth,
+            alpha,
+            minprop,
+            num_random_splits,
+            sample_size_pct,
+            importance_mode,
+            split_mode,
+            verbose,
+            seed,
+            num_threads,
+            save_memory,
+        )
 
         # Saving the attributes
         self.save_properties()
@@ -387,58 +404,59 @@ class BaseSurvivalForest(BaseModel):
             self.variable_importance[features[i]] = value
 
         # Saving the importance in a dataframe
-        self.variable_importance_table = pd.DataFrame(
-            data={'feature': list(self.variable_importance.keys()),
-                  'importance': list(self.variable_importance.values())
-                    },
-            columns=['feature', 'importance']).\
-            sort_values('importance', ascending=0).reset_index(drop=True)
-        importance = self.variable_importance_table['importance'].values
-        importance = np.maximum(importance, 0.)
-        sum_imp = sum(importance)*1.
-        self.variable_importance_table['pct_importance']= importance/sum_imp
+        self.variable_importance_table = (
+            pd.DataFrame(
+                data={
+                    "feature": list(self.variable_importance.keys()),
+                    "importance": list(self.variable_importance.values()),
+                },
+                columns=["feature", "importance"],
+            )
+            .sort_values("importance", ascending=0)
+            .reset_index(drop=True)
+        )
+        importance = self.variable_importance_table["importance"].values
+        importance = np.maximum(importance, 0.0)
+        sum_imp = sum(importance) * 1.0
+        self.variable_importance_table["pct_importance"] = importance / sum_imp
 
         return self
 
-
-    def predict(self, X, t = None, num_threads=-1):
-
+    def predict(self, X, t=None, num_threads=-1):
         # Checking if the data has the right format
         X = utils.check_data(X)
         if X.ndim == 1:
-            X = X.reshape(1,-1)
-        T = np.array([1.]*X.shape[0])
-        E = np.array([1.]*X.shape[0])
+            X = X.reshape(1, -1)
+        T = np.array([1.0] * X.shape[0])
+        E = np.array([1.0] * X.shape[0])
         input_data = np.c_[T, E, X]
 
         # Loading the attributes of the model
         self.load_properties()
 
         # Computing Survival
-        survival = np.array(self.model.predict_survival(input_data,num_threads))     
+        survival = np.array(self.model.predict_survival(input_data, num_threads))
 
         # Computing hazard
-        hazard = np.array(self.model.predict_hazard(input_data, num_threads))  
+        hazard = np.array(self.model.predict_hazard(input_data, num_threads))
 
         # Computing density
-        density  = hazard*survival
+        density = hazard * survival
 
         if t is None:
             return hazard, density, survival
         else:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in self.time_buckets]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in self.time_buckets]
             index = np.argmin(min_index)
             return hazard[:, index], density[:, index], survival[:, index]
 
-
     def predict_risk(self, X, num_threads=-1):
-
         # Checking if the data has the right format
         X = utils.check_data(X)
         if X.ndim == 1:
-            X = X.reshape(1,-1)
-        T = np.array([1.]*X.shape[0])
-        E = np.array([1.]*X.shape[0])
+            X = X.reshape(1, -1)
+        T = np.array([1.0] * X.shape[0])
+        E = np.array([1.0] * X.shape[0])
         input_data = np.c_[T, E, X]
 
         # Loading the attributes of the model
@@ -448,97 +466,151 @@ class BaseSurvivalForest(BaseModel):
         risk = self.model.predict_risk(input_data, num_threads)
         return np.array(risk)
 
-
     def save_properties(self):
-        """ Loading the properties of the model """
+        """Loading the properties of the model"""
 
-        self.times                     = self.model.unique_timepoints
-        self.num_trees                 = self.model.num_trees
-        self.chf                       = self.model.chf
-        self.is_ordered                = self.model.is_ordered
-        self.split_varIDs              = self.model.split_varIDs
-        self.split_values              = self.model.split_values
-        self.child_nodeIDs             = self.model.child_nodeIDs
-        self.status_varID              = self.model.status_varID
-        self.overall_prediction_error  = self.model.overall_prediction_error
-        self.dependent_varID           = self.model.dependent_varID
-        self.min_node_size             = self.model.min_node_size
-        self.variable_importance_      = self.model.variable_importance
-        self.mtry                      = self.model.mtry
+        self.times = self.model.unique_timepoints
+        self.num_trees = self.model.num_trees
+        self.chf = self.model.chf
+        self.is_ordered = self.model.is_ordered
+        self.split_varIDs = self.model.split_varIDs
+        self.split_values = self.model.split_values
+        self.child_nodeIDs = self.model.child_nodeIDs
+        self.status_varID = self.model.status_varID
+        self.overall_prediction_error = self.model.overall_prediction_error
+        self.dependent_varID = self.model.dependent_varID
+        self.min_node_size = self.model.min_node_size
+        self.variable_importance_ = self.model.variable_importance
+        self.mtry = self.model.mtry
         self.num_independent_variables = self.model.num_independent_variables
-        self.variable_names            = self.model.variable_names
-
+        self.variable_names = self.model.variable_names
 
     def load_properties(self):
-        """ Loading the properties of the model """
+        """Loading the properties of the model"""
 
-        self.model.unique_timepoints         = self.times
-        self.model.num_trees                 = self.num_trees
-        self.model.chf                       = self.chf
-        self.model.is_ordered                = self.is_ordered
-        self.model.split_varIDs              = self.split_varIDs
-        self.model.split_values              = self.split_values
-        self.model.child_nodeIDs             = self.child_nodeIDs
-        self.model.status_varID              = self.status_varID
-        self.model.overall_prediction_error  = self.overall_prediction_error
-        self.model.dependent_varID           = self.dependent_varID
-        self.model.min_node_size             = self.min_node_size
-        self.model.variable_importance       = self.variable_importance_
-        self.model.mtry                      = self.mtry
+        self.model.unique_timepoints = self.times
+        self.model.num_trees = self.num_trees
+        self.model.chf = self.chf
+        self.model.is_ordered = self.is_ordered
+        self.model.split_varIDs = self.split_varIDs
+        self.model.split_values = self.split_values
+        self.model.child_nodeIDs = self.child_nodeIDs
+        self.model.status_varID = self.status_varID
+        self.model.overall_prediction_error = self.overall_prediction_error
+        self.model.dependent_varID = self.dependent_varID
+        self.model.min_node_size = self.min_node_size
+        self.model.variable_importance = self.variable_importance_
+        self.model.mtry = self.mtry
         self.model.num_independent_variables = self.num_independent_variables
-        self.model.variable_names            = self.variable_names
+        self.model.variable_names = self.variable_names
 
 
 class RandomSurvivalForestModel(BaseSurvivalForest):
-
-    def __init__(self, num_trees = 10):
+    def __init__(self, num_trees=10):
         super(RandomSurvivalForestModel, self).__init__("logrank", num_trees)
 
-    def fit( self, X, T, E, max_features = 'sqrt', max_depth = 5, 
-            min_node_size = 10, num_threads = -1, weights = None, 
-            sample_size_pct = 0.63, importance_mode = 'normalized_permutation', 
-            seed = None, save_memory=False ):
-
-        return super(RandomSurvivalForestModel, self).fit(X=X, T=T, E=E, 
-            max_features=max_features, max_depth=max_depth, weights = weights, 
-            min_node_size=min_node_size, num_threads=num_threads, 
-            sample_size_pct = sample_size_pct, seed = seed, 
-            save_memory=save_memory, importance_mode = importance_mode)
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        max_features="sqrt",
+        max_depth=5,
+        min_node_size=10,
+        num_threads=-1,
+        weights=None,
+        sample_size_pct=0.63,
+        importance_mode="normalized_permutation",
+        seed=None,
+        save_memory=False,
+    ):
+        return super(RandomSurvivalForestModel, self).fit(
+            X=X,
+            T=T,
+            E=E,
+            max_features=max_features,
+            max_depth=max_depth,
+            weights=weights,
+            min_node_size=min_node_size,
+            num_threads=num_threads,
+            sample_size_pct=sample_size_pct,
+            seed=seed,
+            save_memory=save_memory,
+            importance_mode=importance_mode,
+        )
 
 
 class ExtraSurvivalTreesModel(BaseSurvivalForest):
-
-    def __init__(self, num_trees = 10):
+    def __init__(self, num_trees=10):
         super(ExtraSurvivalTreesModel, self).__init__("extratrees", num_trees)
 
-    def fit( self, X, T, E, max_features = 'sqrt', max_depth = 5, 
-            min_node_size = 10, num_threads = -1, weights = None, 
-            sample_size_pct = 0.63,  num_random_splits = 100, 
-            importance_mode = 'normalized_permutation', 
-            seed = None, save_memory=False ):
-
-        return super(ExtraSurvivalTreesModel, self).fit(X=X, T=T, E=E, 
-            max_features=max_features, max_depth=max_depth, weights = weights, 
-            min_node_size=min_node_size, num_threads=num_threads, 
-            sample_size_pct = sample_size_pct, seed = seed, 
-            num_random_splits = num_random_splits, save_memory=save_memory,
-            importance_mode = importance_mode)
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        max_features="sqrt",
+        max_depth=5,
+        min_node_size=10,
+        num_threads=-1,
+        weights=None,
+        sample_size_pct=0.63,
+        num_random_splits=100,
+        importance_mode="normalized_permutation",
+        seed=None,
+        save_memory=False,
+    ):
+        return super(ExtraSurvivalTreesModel, self).fit(
+            X=X,
+            T=T,
+            E=E,
+            max_features=max_features,
+            max_depth=max_depth,
+            weights=weights,
+            min_node_size=min_node_size,
+            num_threads=num_threads,
+            sample_size_pct=sample_size_pct,
+            seed=seed,
+            num_random_splits=num_random_splits,
+            save_memory=save_memory,
+            importance_mode=importance_mode,
+        )
 
 
 class ConditionalSurvivalForestModel(BaseSurvivalForest):
-
-    def __init__(self, num_trees = 10):
+    def __init__(self, num_trees=10):
         super(ConditionalSurvivalForestModel, self).__init__("maxstat", num_trees)
 
-    def fit( self, X, T, E, max_features = 'sqrt', max_depth = 5, 
-            min_node_size = 10, num_threads = -1, weights = None, 
-            sample_size_pct = 0.63, alpha = 0.5, minprop=0.1,
-            importance_mode = 'normalized_permutation', seed = None, 
-            save_memory=False ):
-
-        return super(ConditionalSurvivalForestModel, self).fit(X=X, T=T, E=E, 
-            max_features = max_features, max_depth = max_depth, 
-            min_node_size = min_node_size, num_threads = num_threads, 
-            weights = weights, sample_size_pct = sample_size_pct, 
-            alpha = alpha, minprop=minprop, importance_mode = importance_mode, 
-            seed = seed, save_memory=save_memory )
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        max_features="sqrt",
+        max_depth=5,
+        min_node_size=10,
+        num_threads=-1,
+        weights=None,
+        sample_size_pct=0.63,
+        alpha=0.5,
+        minprop=0.1,
+        importance_mode="normalized_permutation",
+        seed=None,
+        save_memory=False,
+    ):
+        return super(ConditionalSurvivalForestModel, self).fit(
+            X=X,
+            T=T,
+            E=E,
+            max_features=max_features,
+            max_depth=max_depth,
+            min_node_size=min_node_size,
+            num_threads=num_threads,
+            weights=weights,
+            sample_size_pct=sample_size_pct,
+            alpha=alpha,
+            minprop=minprop,
+            importance_mode=importance_mode,
+            seed=seed,
+            save_memory=save_memory,
+        )

--- a/pysurvival/models/svm.py
+++ b/pysurvival/models/svm.py
@@ -1,100 +1,104 @@
 from __future__ import absolute_import
-import torch 
+
+import os
+
 import numpy as np
 import pandas as pd
-import scipy
-import os
-import copy
+
 from pysurvival import utils
-from pysurvival.utils import optimization as opt
 from pysurvival.models import BaseModel
 from pysurvival.models._svm import _SVMModel
-
+from pysurvival.utils import optimization as opt
 
 # Available Kernel functions
-KERNELS = { 'Linear': 0, 'Polynomial': 1, 'Gaussian':2, 'Normal':2,
-            'Exponential':3, 'Tanh':4, 'Sigmoid': 5, 'Rational Quadratic':6,
-            'Inverse Multiquadratic': 7,  'Multiquadratic': 8}
+KERNELS = {
+    "Linear": 0,
+    "Polynomial": 1,
+    "Gaussian": 2,
+    "Normal": 2,
+    "Exponential": 3,
+    "Tanh": 4,
+    "Sigmoid": 5,
+    "Rational Quadratic": 6,
+    "Inverse Multiquadratic": 7,
+    "Multiquadratic": 8,
+}
 
-REVERSE_KERNELS = {value:key for (key, value) in KERNELS.items() }
-
+REVERSE_KERNELS = {value: key for (key, value) in KERNELS.items()}
 
 
 class SurvivalSVMModel(BaseModel):
-    """ Survival Support Vector Machine model:
-        --------------------------------------
+    """Survival Support Vector Machine model:
+    --------------------------------------
 
-        The purpose of the model is to help us look at Survival Analysis 
-        as a Ranking Problem.
-        Indeed, the idea behind formulating the survival problem as a ranking 
-        problem is that in some applications, like clinical applications, 
-        one is only interested in defining risks groups, and not the prediction 
-        of the survival time, but in whether the unit has a high or low risk for 
-        the event to occur. 
+    The purpose of the model is to help us look at Survival Analysis
+    as a Ranking Problem.
+    Indeed, the idea behind formulating the survival problem as a ranking
+    problem is that in some applications, like clinical applications,
+    one is only interested in defining risks groups, and not the prediction
+    of the survival time, but in whether the unit has a high or low risk for
+    the event to occur.
 
-        The current implementation is based on the "Rank Support Vector Machines 
-        (RankSVMs)" developed by Van Belle et al. This allows us to compute a 
-        convex quadratic loss function, so that we can use the Newton 
-        optimization to minimize it.
+    The current implementation is based on the "Rank Support Vector Machines
+    (RankSVMs)" developed by Van Belle et al. This allows us to compute a
+    convex quadratic loss function, so that we can use the Newton
+    optimization to minimize it.
 
-        References:
-        * Fast Training of Support Vector Machines for Survival Analysis
-          from Sebastian Posterl, Nassir Navab, and Amin Katouzian
-          https://link.springer.com/chapter/10.1007/978-3-319-23525-7_15
-        * An Efficient Training Algorithm for Kernel Survival Support Vector 
-          Machines from Sebastian Posterl, Nassir Navab, and Amin Katouzian
-          https://arxiv.org/abs/1611.07054
-        * Support vector machines for survival analysis.
-          Van Belle, V., Pelckmans, K., Suykens, J.A., Van Huffel, S.
-          ftp://ftp.esat.kuleuven.be/sista/kpelckma/kp07-70.pdf
+    References:
+    * Fast Training of Support Vector Machines for Survival Analysis
+      from Sebastian Posterl, Nassir Navab, and Amin Katouzian
+      https://link.springer.com/chapter/10.1007/978-3-319-23525-7_15
+    * An Efficient Training Algorithm for Kernel Survival Support Vector
+      Machines from Sebastian Posterl, Nassir Navab, and Amin Katouzian
+      https://arxiv.org/abs/1611.07054
+    * Support vector machines for survival analysis.
+      Van Belle, V., Pelckmans, K., Suykens, J.A., Van Huffel, S.
+      ftp://ftp.esat.kuleuven.be/sista/kpelckma/kp07-70.pdf
 
 
-        Parameters:
-        -----------
-        * kernel: str (default="linear")
-            The type of kernel used to fit the model. Here's the list
-            of available kernels:
-            
-            * linear
-            * polynomial
-            * gaussian
-            * exponential
-            * tanh
-            * sigmoid
-            * rational_quadratic
-            * inverse_multiquadratic
-            * multiquadratic
+    Parameters:
+    -----------
+    * kernel: str (default="linear")
+        The type of kernel used to fit the model. Here's the list
+        of available kernels:
 
-        * scale: float (default=1)
-            Scale parameter of the kernel function
-            
-        * offset: float (default=0)
-            Offset parameter of the kernel function
-            
-        * degree: float (default=1)
-            Degree parameter of the polynomial/kernel function
+        * linear
+        * polynomial
+        * gaussian
+        * exponential
+        * tanh
+        * sigmoid
+        * rational_quadratic
+        * inverse_multiquadratic
+        * multiquadratic
+
+    * scale: float (default=1)
+        Scale parameter of the kernel function
+
+    * offset: float (default=0)
+        Offset parameter of the kernel function
+
+    * degree: float (default=1)
+        Degree parameter of the polynomial/kernel function
 
     """
 
-
-    def __init__(self, kernel = "linear", scale=1., offset=0., degree=1.,
-      auto_scaler = True):
-
-
+    def __init__(self, kernel="linear", scale=1.0, offset=0.0, degree=1.0, auto_scaler=True):
         # Ensuring that the provided kernel is available
-        valid_kernel = [key for key in KERNELS.keys() \
-        if kernel.lower().replace('_', ' ') in key.lower().replace('_', ' ')]
+        valid_kernel = [
+            key
+            for key in KERNELS.keys()
+            if kernel.lower().replace("_", " ") in key.lower().replace("_", " ")
+        ]
 
         if len(valid_kernel) == 0:
-            raise NotImplementedError('{} is not a valid kernel function.'
-                .format(kernel))
+            raise NotImplementedError("{} is not a valid kernel function.".format(kernel))
         else:
             kernel_type = KERNELS[valid_kernel[0]]
             kernel = valid_kernel[0]
 
         # Checking the kernel parameters
-        if not (degree >= 0. and \
-          (isinstance(degree, float) or isinstance(degree, int)) ):
+        if not (degree >= 0.0 and (isinstance(degree, float) or isinstance(degree, int))):
             error = "degree parameter is not valid. degree is a >= 0 value"
             raise ValueError(error)
 
@@ -114,93 +118,95 @@ class SurvivalSVMModel(BaseModel):
         self.degree = degree
 
         # Initializing the C++ object
-        self.model = _SVMModel( self.kernel_type, self.scale, self.offset, 
-          self.degree)
+        self.model = _SVMModel(self.kernel_type, self.scale, self.offset, self.degree)
 
         # Initializing the elements from BaseModel
         super(SurvivalSVMModel, self).__init__(auto_scaler)
 
-        
-
     def __repr__(self):
-        """ Creates the representation of the Object """
+        """Creates the representation of the Object"""
 
         self.name = self.__class__.__name__
-        if 'kernel' in self.name :
-            self.name += "(kernel: '{}'".format(self.kernel) + ')'
+        if "kernel" in self.name:
+            self.name += "(kernel: '{}'".format(self.kernel) + ")"
         return self.name
 
-
     def save(self, path_file):
-        """ Save the model paremeters of the model (.params) and Compress 
-            them into a zip file
+        """Save the model paremeters of the model (.params) and Compress
+        them into a zip file
         """
 
         # Ensuring the file has the proper name
-        folder_name = os.path.dirname(path_file) + '/'
+        folder_name = os.path.dirname(path_file) + "/"
         file_name = os.path.basename(path_file)
 
         # Checking if the folder is accessible
         if not os.access(folder_name, os.W_OK):
-            error_msg = '{} is not an accessible directory.'.format(folder_name)
+            error_msg = "{} is not an accessible directory.".format(folder_name)
             raise OSError(error_msg)
 
         # Delete the C++ object before saving
         del self.model
-        
+
         # Saving the model
         super(SurvivalSVMModel, self).save(path_file)
 
         # Re-introduce the C++ object
-        self.model = _SVMModel( self.kernel_type, self.scale, self.offset, 
-          self.degree)
+        self.model = _SVMModel(self.kernel_type, self.scale, self.offset, self.degree)
         self.load_properties()
-        
 
     def load(self, path_file):
-        """ Load the model parameters from a zip file into a C++ external
-            model 
-        """        
+        """Load the model parameters from a zip file into a C++ external
+        model
+        """
         # Loading the model
         super(SurvivalSVMModel, self).load(path_file)
 
         # Re-introduce the C++ object
-        self.model = _SVMModel( self.kernel_type, self.scale, self.offset, 
-          self.degree)
+        self.model = _SVMModel(self.kernel_type, self.scale, self.offset, self.degree)
         self.load_properties()
 
-
-    def fit(self, X, T, E, with_bias = True, init_method='glorot_normal', 
-            lr = 1e-2, max_iter = 100, l2_reg = 1e-4, tol = 1e-3, 
-            verbose = True):
+    def fit(
+        self,
+        X,
+        T,
+        E,
+        with_bias=True,
+        init_method="glorot_normal",
+        lr=1e-2,
+        max_iter=100,
+        l2_reg=1e-4,
+        tol=1e-3,
+        verbose=True,
+    ):
         """
         Fitting a Survival Support Vector Machine model.
 
-        As the Hessian matrix of the log-likelihood can be 
-        calculated without too much effort, the model parameters are 
+        As the Hessian matrix of the log-likelihood can be
+        calculated without too much effort, the model parameters are
         computed using the Newton_Raphson Optimization scheme:
                 W_new = W_old - lr*<Hessian^(-1), gradient>
 
         Arguments:
         ---------
-        
+
         * `X` : array-like, shape=(n_samples, n_features)
             The input samples.
 
-        * `T` : array-like, shape = [n_samples] 
+        * `T` : array-like, shape = [n_samples]
             The target values describing when the event of interest or censoring
             occurred
 
-        * `E` : array-like, shape = [n_samples] 
+        * `E` : array-like, shape = [n_samples]
             The Event indicator array such that E = 1. if the event occurred
             E = 0. if censoring occurred
 
         * `with_bias`: bool (default=True)
-            Whether a bias should be added 
+            Whether a bias should be added
 
         * `init_method` : str (default = 'glorot_uniform')
             Initialization method to use. Here are the possible options:
-                * 'glorot_uniform': Glorot/Xavier uniform initializer, 
+                * 'glorot_uniform': Glorot/Xavier uniform initializer,
                 * 'he_uniform': He uniform variance scaling initializer
                 * 'uniform': Initializing tensors with uniform (-1, 1) distribution
                 * 'glorot_normal': Glorot normal initializer,
@@ -240,14 +246,14 @@ class SurvivalSVMModel(BaseModel):
         from pysurvival.models.simulations import SimulationModel
         from pysurvival.utils.metrics import concordance_index
         from sklearn.model_selection import train_test_split
-        from scipy.stats.stats import pearsonr   
+        from scipy.stats.stats import pearsonr
         # %pylab inline # to use in jupyter notebooks
 
         #### 2 - Generating the dataset from the parametric model
         # Initializing the simulation model
-        sim = SimulationModel( survival_distribution = 'Log-Logistic',  
+        sim = SimulationModel( survival_distribution = 'Log-Logistic',
                                risk_type = 'linear',
-                               censored_parameter = 1.1, 
+                               censored_parameter = 1.1,
                                alpha = 1.5, beta = 4)
 
         # Generating N Random samples
@@ -272,7 +278,7 @@ class SurvivalSVMModel(BaseModel):
         #### 4 - Creating an instance of the SVM model and fitting the data.
         svm_model = LinearSVMModel()
         svm_model = KernelSVMModel(kernel='Gaussian', scale=0.25)
-        svm_model.fit(X_train, T_train, E_train, init_method='he_uniform', 
+        svm_model.fit(X_train, T_train, E_train, init_method='he_uniform',
             with_bias = True, lr = 0.5,  tol = 1e-3,  l2_reg = 1e-3)
 
         #### 5 - Cross Validation / Model Performances
@@ -283,7 +289,7 @@ class SurvivalSVMModel(BaseModel):
         # Comparing risk scores
         svm_risks = svm_model.predict_risk(X_test)
         actual_risks = sim.predict_risk(X_test).flatten()
-        print("corr={:.4f}, p_value={:.5f}".format(*pearsonr(svm_risks, 
+        print("corr={:.4f}, p_value={:.5f}".format(*pearsonr(svm_risks,
             actual_risks)))# corr=-0.9992, p_value=0.00000
 
         """
@@ -293,87 +299,83 @@ class SurvivalSVMModel(BaseModel):
         if isinstance(X, pd.DataFrame):
             self.variables = X.columns.tolist()
         else:
-            self.variables = ['x_{}'.format(i) for i in range(self.num_vars)]
-        
+            self.variables = ["x_{}".format(i) for i in range(self.num_vars)]
+
         # Adding a bias or not
         self.with_bias = with_bias
         if with_bias:
-            self.variables += ['intercept']
-        p = int(self.num_vars + 1.*with_bias)
+            self.variables += ["intercept"]
+        p = int(self.num_vars + 1.0 * with_bias)
 
-        # Checking the format of the data 
+        # Checking the format of the data
         X, T, E = utils.check_data(X, T, E)
 
         if with_bias:
             # Adding the intercept
-            X = np.c_[X, [1.]*N]
-        X = self.scaler.fit_transform( X )
+            X = np.c_[X, [1.0] * N]
+        X = self.scaler.fit_transform(X)
 
-        # Initializing the parameters 
+        # Initializing the parameters
         if self.kernel_type == 0:
             W = np.zeros((p, 1))
         else:
             W = np.zeros((N, 1))
         W = opt.initialization(init_method, W, False).flatten()
         W = W.astype(np.float64)
-        
-        # Optimizing to find best parameters 
-        self.model.newton_optimization(X, T, E, W, lr, l2_reg, 
-                                 tol, max_iter, verbose)
+
+        # Optimizing to find best parameters
+        self.model.newton_optimization(X, T, E, W, lr, l2_reg, tol, max_iter, verbose)
         self.save_properties()
 
         return self
 
-
     def save_properties(self):
-        """ Loading the properties of the model """
+        """Loading the properties of the model"""
 
-        self.weights        = np.array( self.model.W )
-        self.Kernel_Matrix  = np.array( self.model.Kernel_Matrix )
-        self.kernel_type    =           self.model.kernel_type 
-        self.scale          =           self.model.scale 
-        self.offset         =           self.model.offset 
-        self.degree         =           self.model.degree 
-        self.loss           = np.array( self.model.loss )
-        self.inv_Hessian    = np.array( self.model.inv_Hessian )
-        self.loss_values    = np.array( self.model.loss_values )
-        self.grad2_values   = np.array( self.model.grad2_values )
-        self.internal_X     = np.array( self.model.internal_X )
-
+        self.weights = np.array(self.model.W)
+        self.Kernel_Matrix = np.array(self.model.Kernel_Matrix)
+        self.kernel_type = self.model.kernel_type
+        self.scale = self.model.scale
+        self.offset = self.model.offset
+        self.degree = self.model.degree
+        self.loss = np.array(self.model.loss)
+        self.inv_Hessian = np.array(self.model.inv_Hessian)
+        self.loss_values = np.array(self.model.loss_values)
+        self.grad2_values = np.array(self.model.grad2_values)
+        self.internal_X = np.array(self.model.internal_X)
 
     def load_properties(self):
-        """ Loading the properties of the model """
+        """Loading the properties of the model"""
 
-        self.model.W              = self.weights
-        self.model.Kernel_Matrix  = self.Kernel_Matrix
-        self.model.kernel_type    = self.kernel_type
-        self.model.scale          = self.scale
-        self.model.offset         = self.offset
-        self.model.degree         = self.degree
-        self.model.loss           = self.loss
-        self.model.inv_Hessian    = self.inv_Hessian
-        self.model.loss_values    = self.loss_values
-        self.model.grad2_values   = self.grad2_values
-        self.model.internal_X     = self.internal_X 
-        self.kernel               = REVERSE_KERNELS[self.kernel_type]
+        self.model.W = self.weights
+        self.model.Kernel_Matrix = self.Kernel_Matrix
+        self.model.kernel_type = self.kernel_type
+        self.model.scale = self.scale
+        self.model.offset = self.offset
+        self.model.degree = self.degree
+        self.model.loss = self.loss
+        self.model.inv_Hessian = self.inv_Hessian
+        self.model.loss_values = self.loss_values
+        self.model.grad2_values = self.grad2_values
+        self.model.internal_X = self.internal_X
+        self.kernel = REVERSE_KERNELS[self.kernel_type]
 
+    def predict_risk(self, x, use_log=False):
+        """Predicts the Risk Score
 
-    def predict_risk(self, x, use_log = False):
-        """ Predicts the Risk Score
-        
-            Parameter
-            ----------
-            * `x`, np.ndarray
-                 array-like representing the datapoints
+        Parameter
+        ----------
+        * `x`, np.ndarray
+             array-like representing the datapoints
 
-            * `use_log`: bool - (default=False)
-                Applies the log function to the risk values
+        * `use_log`: bool - (default=False)
+            Applies the log function to the risk values
 
-            Returns
-            -------
-            * `risk_score`, np.ndarray
-                array-like representing the prediction of Risk Score function
-        """        
+        Returns
+        -------
+        * `risk_score`, np.ndarray
+            array-like representing the prediction of Risk Score function
+        """
 
         # Ensuring that the C++ model has the fitted parameters
         self.load_properties()
@@ -384,63 +386,52 @@ class SurvivalSVMModel(BaseModel):
         # Scaling the dataset
         if x.ndim == 1:
             if self.with_bias:
-                x = np.r_[x, 1.]
-            x = self.scaler.transform( x.reshape(1, -1) )
+                x = np.r_[x, 1.0]
+            x = self.scaler.transform(x.reshape(1, -1))
         elif x.ndim == 2:
             n = x.shape[0]
             if self.with_bias:
-                x = np.c_[x, [1.]*n]
-            x = self.scaler.transform( x )
+                x = np.c_[x, [1.0] * n]
+            x = self.scaler.transform(x)
 
         # Calculating prdiction
-        risk = np.exp( self.model.get_score(x) )
+        risk = np.exp(self.model.get_score(x))
 
         if use_log:
-            return np.log( risk )
+            return np.log(risk)
         else:
             return risk
-
-
 
     def predict_cumulative_hazard(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
 
-
     def predict_cdf(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
-
 
     def predict_survival(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
 
-
     def predict_density(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
-
 
     def predict_hazard(self, *args, **kargs):
         raise NotImplementedError(self.not_implemented_error)
 
 
-
 class LinearSVMModel(SurvivalSVMModel):
-
-    def __init__(self, auto_scaler = True):
-
-        super(LinearSVMModel, self).__init__(kernel = "linear", scale=1., 
-            offset=0., degree=1., auto_scaler = True)
-
+    def __init__(self, auto_scaler=True):
+        super(LinearSVMModel, self).__init__(
+            kernel="linear", scale=1.0, offset=0.0, degree=1.0, auto_scaler=True
+        )
 
 
 class KernelSVMModel(SurvivalSVMModel):
-
-    def __init__(self, kernel = "gaussian", scale=1., offset=0., degree=1.,
-      auto_scaler = True):
-
+    def __init__(self, kernel="gaussian", scale=1.0, offset=0.0, degree=1.0, auto_scaler=True):
         if "linear" in kernel.lower():
             error = "To use a 'linear' svm model, create an instance of"
             error += "pysurvival.models.svm.LinearSVMModel"
             raise ValueError(error)
 
-        super(KernelSVMModel, self).__init__(kernel = kernel, scale=scale, 
-            offset=offset, degree=degree, auto_scaler = auto_scaler)
+        super(KernelSVMModel, self).__init__(
+            kernel=kernel, scale=scale, offset=offset, degree=degree, auto_scaler=auto_scaler
+        )

--- a/pysurvival/utils/__init__.py
+++ b/pysurvival/utils/__init__.py
@@ -1,73 +1,72 @@
 import copy
+
 import numpy as np
 import pandas as pd
+
 from pysurvival.utils._functions import _logrankScores
-# %matplotlib inline for Jupyter notebooks 
+
+# %matplotlib inline for Jupyter notebooks
 
 
 def as_bytes(string_array, python_version=3):
-    """ Transforming an array of string into an array of bytes in Python 3 
-    """
+    """Transforming an array of string into an array of bytes in Python 3"""
 
     if python_version >= 3:
         results = []
         for s in string_array:
             # results.append( codecs.latin_1_encode(s)[0] )
-            results.append( s.encode('utf-8') )
+            results.append(s.encode("utf-8"))
 
     else:
         results = string_array
 
     return results
-    
+
 
 def check_data(*args):
-    """ Makes sure that the given inputs are numpy arrays, list or 
-        pandas DataFrames.
+    """Makes sure that the given inputs are numpy arrays, list or
+    pandas DataFrames.
 
-        Parameters
-        ----------
-        * args : tuple of objects
-                 Input object to check / convert.
+    Parameters
+    ----------
+    * args : tuple of objects
+             Input object to check / convert.
 
-        Returns
-        -------
-        * result : tuple of numpy arrays
-                   The converted and validated arg.
+    Returns
+    -------
+    * result : tuple of numpy arrays
+               The converted and validated arg.
 
-        If the input isn't numpy arrays, list or pandas DataFrames, it will
-        fail and ask to provide the valid format.
+    If the input isn't numpy arrays, list or pandas DataFrames, it will
+    fail and ask to provide the valid format.
     """
 
     result = ()
     for i, arg in enumerate(args):
-
-        if len(arg) == 0 :
+        if len(arg) == 0:
             error = " The input is empty. "
             error += "Please provide at least 1 element in the array."
-            raise IndexError(error)         
+            raise IndexError(error)
 
         else:
-
-            if isinstance(arg, np.ndarray) :
-                x = ( arg.astype(np.double),  )
+            if isinstance(arg, np.ndarray):
+                x = (arg.astype(np.double),)
             elif isinstance(arg, list):
-                x = ( np.asarray(arg).astype(np.double),  )
+                x = (np.asarray(arg).astype(np.double),)
             elif isinstance(arg, pd.Series):
-                x = ( arg.values.astype(np.double),  )
+                x = (arg.values.astype(np.double),)
             elif isinstance(arg, pd.DataFrame):
-                x = ( arg.values.astype(np.double),  )
+                x = (arg.values.astype(np.double),)
             else:
-                
                 error = "{arg} is not a valid data format. "
                 error += "Only use 'list', 'np.ndarray', "
                 error += "'pd.Series' "
                 error += "'pd.DataFrame' ".format(arg=type(arg))
                 raise TypeError(error)
-            
-            if np.sum( np.isnan(x) ) > 0. :
+
+            if np.sum(np.isnan(x)) > 0.0:
                 error = "The #{} argument contains null values"
-                error = error.format(i+1)
+                error = error.format(i + 1)
                 raise ValueError(error)
 
             if len(args) > 1:
@@ -75,18 +74,17 @@ def check_data(*args):
             else:
                 result = x[0]
 
-    return result               
+    return result
 
 
 def as_bytes(string_array, python_version=3):
-    """ Transforming an array of string into an array of bytes in Python 3 
-    """
+    """Transforming an array of string into an array of bytes in Python 3"""
 
     if python_version >= 3:
         results = []
         for s in string_array:
             # results.append( codecs.latin_1_encode(s)[0] )
-            results.append( s.encode('utf-8') )
+            results.append(s.encode("utf-8"))
     else:
         results = string_array
 
@@ -94,17 +92,17 @@ def as_bytes(string_array, python_version=3):
 
 
 def rank_scores(T, E):
-    """ 
+    """
     Computing the ranks for each survival time T
 
         Parameters:
         -----------
 
-        * T : array-like, shape = [n_samples] 
+        * T : array-like, shape = [n_samples]
             The target values describing when the event of interest or censoring
             occured
 
-        * E : array-like, shape = [n_samples] 
+        * E : array-like, shape = [n_samples]
             The Event indicator array such that E = 1. if the event occured
             E = 0. if censoring occured
 
@@ -114,11 +112,11 @@ def rank_scores(T, E):
             ranks for each survival time T
     """
     T, E = check_data(T, E)
-    return _logrankScores(T,E)
+    return _logrankScores(T, E)
 
 
 def save_model(model, path_file):
-    """ Save the model and its parameters, and compress them into a zip file 
+    """Save the model and its parameters, and compress them into a zip file
 
     Parameters:
     -----------
@@ -126,21 +124,19 @@ def save_model(model, path_file):
         Pysurvival model
 
     * path_file, str
-        address of the file where the model will be loaded from 
+        address of the file where the model will be loaded from
     """
 
     model.save(path_file)
 
 
-
-
 def load_model(path_file):
-    """ Load the model and its parameters from a .zip file 
+    """Load the model and its parameters from a .zip file
 
     Parameters:
     -----------
     * path_file, str
-        address of the file where the model will be loaded from 
+        address of the file where the model will be loaded from
 
     Returns:
     --------
@@ -150,6 +146,7 @@ def load_model(path_file):
 
     # Initializing a base model
     from pysurvival.models import BaseModel
+
     base_model = BaseModel()
 
     # Temporary loading the model
@@ -157,110 +154,99 @@ def load_model(path_file):
     model_name = base_model.name
 
     # Loading the actual Pysurvival model - Kaplan-Meier
-    if 'kaplanmeier' in model_name.lower():
-
-        if 'smooth' in model_name.lower():
+    if "kaplanmeier" in model_name.lower():
+        if "smooth" in model_name.lower():
             from pysurvival.models.non_parametric import SmoothKaplanMeierModel
+
             pysurvival_model = SmoothKaplanMeierModel()
 
         else:
             from pysurvival.models.non_parametric import KaplanMeierModel
+
             pysurvival_model = KaplanMeierModel()
 
-
-    elif 'linearmultitask' in model_name.lower():
-
+    elif "linearmultitask" in model_name.lower():
         from pysurvival.models.multi_task import LinearMultiTaskModel
+
         pysurvival_model = LinearMultiTaskModel()
 
-
-    elif 'neuralmultitask' in model_name.lower():
-
+    elif "neuralmultitask" in model_name.lower():
         from pysurvival.models.multi_task import NeuralMultiTaskModel
-        structure = [ {'activation': 'relu', 'num_units': 128}, ]         
+
+        structure = [
+            {"activation": "relu", "num_units": 128},
+        ]
         pysurvival_model = NeuralMultiTaskModel(structure=structure)
 
-
-    elif 'exponential' in model_name.lower():
-
+    elif "exponential" in model_name.lower():
         from pysurvival.models.parametric import ExponentialModel
+
         pysurvival_model = ExponentialModel()
 
-
-    elif 'weibull' in model_name.lower():
-
+    elif "weibull" in model_name.lower():
         from pysurvival.models.parametric import WeibullModel
+
         pysurvival_model = WeibullModel()
 
-
-    elif 'gompertz' in model_name.lower():
-
+    elif "gompertz" in model_name.lower():
         from pysurvival.models.parametric import GompertzModel
+
         pysurvival_model = GompertzModel()
 
-
-    elif 'loglogistic' in model_name.lower():
-
+    elif "loglogistic" in model_name.lower():
         from pysurvival.models.parametric import LogLogisticModel
+
         pysurvival_model = LogLogisticModel()
 
-
-    elif 'lognormal' in model_name.lower():
-
+    elif "lognormal" in model_name.lower():
         from pysurvival.models.parametric import LogNormalModel
+
         pysurvival_model = LogNormalModel()
 
-
-    elif 'simulation' in model_name.lower():
-
+    elif "simulation" in model_name.lower():
         from pysurvival.models.simulations import SimulationModel
+
         pysurvival_model = SimulationModel()
 
-
-    elif 'coxph' in model_name.lower():
-
-        if 'nonlinear' in model_name.lower():
+    elif "coxph" in model_name.lower():
+        if "nonlinear" in model_name.lower():
             from pysurvival.models.semi_parametric import NonLinearCoxPHModel
+
             pysurvival_model = NonLinearCoxPHModel()
 
         else:
             from pysurvival.models.semi_parametric import CoxPHModel
+
             pysurvival_model = CoxPHModel()
 
-
-    elif 'random' in model_name.lower() and 'survival' in model_name.lower():
-
+    elif "random" in model_name.lower() and "survival" in model_name.lower():
         from pysurvival.models.survival_forest import RandomSurvivalForestModel
+
         pysurvival_model = RandomSurvivalForestModel()
 
-
-    elif 'extra' in model_name.lower() and 'survival' in model_name.lower():
-
+    elif "extra" in model_name.lower() and "survival" in model_name.lower():
         from pysurvival.models.survival_forest import ExtraSurvivalTreesModel
+
         pysurvival_model = ExtraSurvivalTreesModel()
 
-
-    elif 'condi' in model_name.lower() and 'survival' in model_name.lower():
-
+    elif "condi" in model_name.lower() and "survival" in model_name.lower():
         from pysurvival.models.survival_forest import ConditionalSurvivalForestModel
+
         pysurvival_model = ConditionalSurvivalForestModel()
 
-
-    elif 'svm' in model_name.lower() :
-
-        if 'linear' in model_name.lower():
-
+    elif "svm" in model_name.lower():
+        if "linear" in model_name.lower():
             from pysurvival.models.svm import LinearSVMModel
+
             pysurvival_model = LinearSVMModel()
 
-        elif 'kernel' in model_name.lower():
-
+        elif "kernel" in model_name.lower():
             from pysurvival.models.svm import KernelSVMModel
+
             pysurvival_model = KernelSVMModel()
 
     else:
-        raise NotImplementedError('{} is not a valid pysurvival model.'
-            .format(model_name))
+        raise NotImplementedError("{} is not a valid pysurvival model.".format(model_name))
 
     # Transferring the components
     pysurvival_model.__dict__.update(copy.deepcopy(base_model.__dict__))

--- a/pysurvival/utils/display.py
+++ b/pysurvival/utils/display.py
@@ -1,35 +1,33 @@
 import numpy as np
-import pandas as pd
-from matplotlib import pyplot as plt
 from matplotlib import cm as cm
 from matplotlib import colors
+from matplotlib import pyplot as plt
 from matplotlib.patches import Rectangle
+from sklearn.metrics import mean_absolute_error, mean_squared_error, median_absolute_error
+
 from pysurvival import utils
-from pysurvival.utils import metrics
-from pysurvival.utils.metrics import brier_score
-from sklearn.metrics import mean_absolute_error, mean_squared_error
-from sklearn.metrics import median_absolute_error
 from pysurvival.models.non_parametric import KaplanMeierModel
+from pysurvival.utils.metrics import brier_score
 
 
-def display_loss_values(model, figure_size = (18, 5)):
-    """ Display the loss function values of the model fitting 
+def display_loss_values(model, figure_size=(18, 5)):
+    """Display the loss function values of the model fitting
 
-        Parameters:
-        -----------
-        * model : pysurvival model
-            The model that will be used for prediction
+    Parameters:
+    -----------
+    * model : pysurvival model
+        The model that will be used for prediction
 
-        * figure_size: tuple of double (default= (18, 5))
-            width, height in inches representing the size of the chart 
+    * figure_size: tuple of double (default= (18, 5))
+        width, height in inches representing the size of the chart
     """
 
     # Check that the model is not a Non-Parametric model
-    if 'kaplan' in model.name.lower() :
+    if "kaplan" in model.name.lower():
         error = "This function cannot only take as input a Non-Parametric model"
         raise NotImplementedError(error)
 
-    if 'simulation' in model.name.lower() :
+    if "simulation" in model.name.lower():
         error = "This function cannot only take as input a simulation model"
         raise NotImplementedError(error)
 
@@ -37,41 +35,47 @@ def display_loss_values(model, figure_size = (18, 5)):
     loss_values = model.loss_values
 
     # Extracting the norm 2 of the gradient, if it exists
-    grad2_values = model.__dict__.get('grad2_values')
+    grad2_values = model.__dict__.get("grad2_values")
     if grad2_values is None:
         order = 1
-    else :
+    else:
         order = 2
-   
+
     # Displaying the loss values bsed on the type of optimization
     if order == 1:
         title = "Loss function values"
         fig, ax = plt.subplots(figsize=figure_size)
-        ax.plot( loss_values, color = 'blue',  label = 'Loss values')
-        ax.set_xlabel( 'Number of epochs', fontsize=10)
+        ax.plot(loss_values, color="blue", label="Loss values")
+        ax.set_xlabel("Number of epochs", fontsize=10)
         plt.legend(fontsize=10)
         plt.title(title, fontsize=10)
         plt.show()
 
     elif order == 2:
-
-        # Initializing Chart 
-        fig = plt.figure( figsize=figure_size )
-        fig.suptitle( 'Loss function $l$ and $|| gradient ||_{L_{2}}$', 
-                     fontsize=12, fontweight='bold')
+        # Initializing Chart
+        fig = plt.figure(figsize=figure_size)
+        fig.suptitle(
+            "Loss function $l$ and $|| gradient ||_{L_{2}}$", fontsize=12, fontweight="bold"
+        )
 
         # Plotting loss function
         ax1 = fig.add_subplot(111)
-        ax1.set_xlabel('epochs' )
-        ax1.set_ylabel('Loss function $l$')
-        pl1 = ax1.plot( range( len(loss_values)) , loss_values, 
-                  label = 'Loss function $l$', color = 'blue', linestyle = '--')
+        ax1.set_xlabel("epochs")
+        ax1.set_ylabel("Loss function $l$")
+        pl1 = ax1.plot(
+            range(len(loss_values)),
+            loss_values,
+            label="Loss function $l$",
+            color="blue",
+            linestyle="--",
+        )
 
         # Plotting ||grad|| values
         ax2 = ax1.twinx()
-        pl2 = ax2.plot( range( len(grad2_values) ) , grad2_values ,
-                  label = '$|| gradient ||_{L_{2}}$', color = 'red')
-        ax2.set_ylabel('$|| gradient ||_{L_{2}}$')
+        pl2 = ax2.plot(
+            range(len(grad2_values)), grad2_values, label="$|| gradient ||_{L_{2}}$", color="red"
+        )
+        ax2.set_ylabel("$|| gradient ||_{L_{2}}$")
 
         # added these three lines
         pl = pl1 + pl2
@@ -79,103 +83,107 @@ def display_loss_values(model, figure_size = (18, 5)):
         ax1.legend(pl, labs, loc=1)
 
         # display chart
-        plt.show() 
-        
+        plt.show()
 
 
-def display_non_parametric(km_model, figure_size = (18, 5) ):
-    """ Plotting the survival function and its lower and upper bounds 
+def display_non_parametric(km_model, figure_size=(18, 5)):
+    """Plotting the survival function and its lower and upper bounds
 
-        Parameters:
-        -----------
-        * km_model : pysurvival Non-Parametric model
-            The model that will be used for prediction
+    Parameters:
+    -----------
+    * km_model : pysurvival Non-Parametric model
+        The model that will be used for prediction
 
-        * figure_size: tuple of double (default= (18, 5))
-            width, height in inches representing the size of the chart 
+    * figure_size: tuple of double (default= (18, 5))
+        width, height in inches representing the size of the chart
     """
 
     # Check that the model is a Non-Parametric model
-    if 'kaplan' not in km_model.name.lower() :
+    if "kaplan" not in km_model.name.lower():
         error = "This function can only take as input a Non-Parametric model"
         raise NotImplementedError(error)
 
     # Title of the chart
-    if 'smooth' in km_model.name.lower() :
+    if "smooth" in km_model.name.lower():
         is_smoothed = True
-        title = 'Smooth Kaplan-Meier Survival function'
+        title = "Smooth Kaplan-Meier Survival function"
     else:
         is_smoothed = False
-        title = 'Kaplan-Meier Survival function'
+        title = "Kaplan-Meier Survival function"
 
     # Initializing the chart
-    fig, ax = plt.subplots(figsize=figure_size )
+    fig, ax = plt.subplots(figsize=figure_size)
 
     # Extracting times and survival function
     times, survival = km_model.times, km_model.survival
 
     # Plotting Survival
-    plt.plot(times, survival, label = title, 
-             color = 'blue', lw = 3)  
+    plt.plot(times, survival, label=title, color="blue", lw=3)
 
     # Defining the x-axis and y-axis
-    ax.set_xlabel('Time')
-    ax.set_ylabel( 'S(t) Survival function' )
+    ax.set_xlabel("Time")
+    ax.set_ylabel("S(t) Survival function")
     ax.set_ylim([0.0, 1.05])
-    ax.set_xlim([0.0, max(times)*1.01])
+    ax.set_xlim([0.0, max(times) * 1.01])
     vals = ax.get_yticks()
-    ax.set_yticklabels(['{:.1f}%'.format(v*100) for v in vals])
+    ax.set_yticklabels(["{:.1f}%".format(v * 100) for v in vals])
     plt.title(title, fontsize=25)
 
     # Extracting times and survival function
     times, survival = km_model.times, km_model.survival
 
-    if is_smoothed :
-
+    if is_smoothed:
         # Display
-        plt.plot(times, survival, label = 'Original Kaplan-Meier', 
-                 color = '#f44141', ls = '-.', lw = 2.5)        
+        plt.plot(times, survival, label="Original Kaplan-Meier", color="#f44141", ls="-.", lw=2.5)
         plt.legend(fontsize=15)
         plt.show()
 
     else:
-
         # Extracting CI
         survival_ci_upper = km_model.survival_ci_upper
         survival_ci_lower = km_model.survival_ci_lower
 
         # Plotting the Confidence Intervals
-        plt.plot(times, survival_ci_upper, 
-                 color='red', alpha =0.1, ls='--')
-        plt.plot(times, survival_ci_lower, 
-                 color='red', alpha =0.1, ls='--')
+        plt.plot(times, survival_ci_upper, color="red", alpha=0.1, ls="--")
+        plt.plot(times, survival_ci_lower, color="red", alpha=0.1, ls="--")
 
         # Filling the areas between the Survival and Confidence Intervals curves
-        plt.fill_between(times, survival, survival_ci_lower, 
-                label='Confidence Interval - lower', color='red', alpha =0.2)
-        plt.fill_between(times, survival, survival_ci_upper, 
-                label='Confidence Interval - upper', color='red', alpha =0.2)
-        
+        plt.fill_between(
+            times,
+            survival,
+            survival_ci_lower,
+            label="Confidence Interval - lower",
+            color="red",
+            alpha=0.2,
+        )
+        plt.fill_between(
+            times,
+            survival,
+            survival_ci_upper,
+            label="Confidence Interval - upper",
+            color="red",
+            alpha=0.2,
+        )
+
         # Display
         plt.legend(fontsize=15)
         plt.show()
 
 
-
 def display_baseline_simulations(sim_model, figure_size=(18, 5)):
-    """ Display Simulation model baseline 
+    """Display Simulation model baseline
 
-        Parameters:
-        -----------
-        * sim_model : pysurvival Simulations model
-            The model that will be used for prediction
+    Parameters:
+    -----------
+    * sim_model : pysurvival Simulations model
+        The model that will be used for prediction
 
-        * figure_size: tuple of double (default= (18, 5))
-            width, height in inches representing the size of the chart 
+    * figure_size: tuple of double (default= (18, 5))
+        width, height in inches representing the size of the chart
     """
 
     # Check that the model is a Non-Parametric model
-    if 'simulation' not in sim_model.name.lower() :
+    if "simulation" not in sim_model.name.lower():
         error = "This function can only take as input a Non-Parametric model"
         raise NotImplementedError(error)
 
@@ -183,21 +191,19 @@ def display_baseline_simulations(sim_model, figure_size=(18, 5)):
     name_survival_distribution = sim_model.survival_distribution
     times = sim_model.times
     baseline_survival = sim_model.baseline_survival
-    title = 'Base Survival function - ' + name_survival_distribution.title()
+    title = "Base Survival function - " + name_survival_distribution.title()
 
     # Display
     fig, ax = plt.subplots(figsize=figure_size)
-    ax.plot( times, baseline_survival, color = 'blue', label = 'baseline')
+    ax.plot(times, baseline_survival, color="blue", label="baseline")
     plt.legend()
     plt.title(title)
     plt.show()
 
 
-
-def integrated_brier_score(model, X, T, E, t_max=None, use_mean_point=True,
-    figure_size=(20, 6.5)):
-    """ The Integrated Brier Score (IBS) provides an overall calculation of 
-        the model performance at all available times.
+def integrated_brier_score(model, X, T, E, t_max=None, use_mean_point=True, figure_size=(20, 6.5)):
+    """The Integrated Brier Score (IBS) provides an overall calculation of
+    the model performance at all available times.
     """
 
     # Computing the brier scores
@@ -210,28 +216,35 @@ def integrated_brier_score(model, X, T, E, t_max=None, use_mean_point=True,
         t_max = min(t_max, max(times))
 
     # Computing the IBS
-    ibs_value = np.trapz(brier_scores, times)/t_max 
+    ibs_value = np.trapz(brier_scores, times) / t_max
 
-    # Displaying the Brier Scores at different t 
-    title = 'Prediction error curve with IBS(t = {:.1f}) = {:.2f}'
+    # Displaying the Brier Scores at different t
+    title = "Prediction error curve with IBS(t = {:.1f}) = {:.2f}"
     title = title.format(t_max, ibs_value)
     fig, ax = plt.subplots(figsize=figure_size)
-    ax.plot( times, brier_scores, color = 'blue', lw = 3)
+    ax.plot(times, brier_scores, color="blue", lw=3)
     ax.set_xlim(-0.01, max(times))
-    ax.axhline(y=0.25, ls = '--', color = 'red')
-    ax.text(0.90*max(times), 0.235, '0.25 limit', fontsize=20, color='brown', 
-        fontweight='bold')
+    ax.axhline(y=0.25, ls="--", color="red")
+    ax.text(0.90 * max(times), 0.235, "0.25 limit", fontsize=20, color="brown", fontweight="bold")
     plt.title(title, fontsize=20)
     plt.show()
 
     return ibs_value
 
 
-
-def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,  
-    figure_size=(16, 6), metrics = ['rmse', 'mean', 'median'], **kwargs):
+def compare_to_actual(
+    model,
+    X,
+    T,
+    E,
+    times=None,
+    is_at_risk=False,
+    figure_size=(16, 6),
+    metrics=["rmse", "mean", "median"],
+    **kwargs
+):
     """
-    Comparing the actual and predicted number of units at risk and units 
+    Comparing the actual and predicted number of units at risk and units
     experiencing an event at each time t.
 
     Parameters:
@@ -242,11 +255,11 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     * X : array-like, shape=(n_samples, n_features)
         The input samples.
 
-    * T : array-like, shape = [n_samples] 
+    * T : array-like, shape = [n_samples]
         The target values describing when the event of interest or censoring
         occured
 
-    * E : array-like, shape = [n_samples] 
+    * E : array-like, shape = [n_samples]
         The Event indicator array such that E = 1. if the event occured
         E = 0. if censoring occured
 
@@ -258,7 +271,7 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
         or the Expected number of units experiencing the events.
 
     * figure_size: tuple of double (default= (16, 6))
-        width, height in inches representing the size of the chart 
+        width, height in inches representing the size of the chart
 
     * metrics: str or list of str (default='all')
         Indicates the performance metrics to compute:
@@ -274,7 +287,7 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     Returns:
     --------
     * results: float or dict
-        Performance metrics   
+        Performance metrics
 
     """
 
@@ -297,33 +310,32 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     actual_lower = []
     predicted = []
     if is_at_risk:
-        model_predicted =  np.sum(model.predict_survival(X, **kwargs), 0)
+        model_predicted = np.sum(model.predict_survival(X, **kwargs), 0)
 
         for t in times:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in model.time_buckets]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in model.time_buckets]
             index = np.argmin(min_index)
-            actual.append(N*kmf.predict_survival(t))
-            actual_upper.append(N*kmf.predict_survival_upper(t))
-            actual_lower.append(N*kmf.predict_survival_lower(t))
-            predicted.append( model_predicted[index] )
+            actual.append(N * kmf.predict_survival(t))
+            actual_upper.append(N * kmf.predict_survival_upper(t))
+            actual_lower.append(N * kmf.predict_survival_lower(t))
+            predicted.append(model_predicted[index])
 
     else:
-        model_predicted =  np.sum(model.predict_density(X, **kwargs), 0)
+        model_predicted = np.sum(model.predict_density(X, **kwargs), 0)
 
         for t in times:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in model.time_buckets]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in model.time_buckets]
             index = np.argmin(min_index)
-            actual.append(N*kmf.predict_density(t))
+            actual.append(N * kmf.predict_density(t))
             h = kmf.predict_hazard(t)
-            actual_upper.append(N*kmf.predict_survival_upper(t)*h)
-            actual_lower.append(N*kmf.predict_survival_lower(t)*h)
-            predicted.append( model_predicted[index] )
+            actual_upper.append(N * kmf.predict_survival_upper(t) * h)
+            actual_lower.append(N * kmf.predict_survival_lower(t) * h)
+            predicted.append(model_predicted[index])
 
     # Computing the performance metrics
     results = None
-    title = 'Actual vs Predicted'
+    title = "Actual vs Predicted"
     if metrics is not None:
-
         # RMSE
         rmse = np.sqrt(mean_squared_error(actual, predicted))
 
@@ -333,116 +345,110 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
         # Mean Abs Error
         mae = mean_absolute_error(actual, predicted)
 
-
-        if isinstance(metrics, str) :
-
+        if isinstance(metrics, str):
             # RMSE
-            if 'rmse' in metrics.lower() or 'root' in metrics.lower():
+            if "rmse" in metrics.lower() or "root" in metrics.lower():
                 results = rmse
                 title += "\n"
                 title += "RMSE = {:.3f}".format(rmse)
 
             # Median Abs Error
-            elif 'median' in metrics.lower() :
+            elif "median" in metrics.lower():
                 results = med_ae
                 title += "\n"
                 title += "Median Abs Error = {:.3f}".format(med_ae)
 
             # Mean Abs Error
-            elif 'mean' in metrics.lower() :
+            elif "mean" in metrics.lower():
                 results = mae
                 title += "\n"
                 title += "Mean Abs Error = {:.3f}".format(mae)
 
             else:
-                raise NotImplementedError('{} is not a valid metric function.'
-                .format(metrics))
+                raise NotImplementedError("{} is not a valid metric function.".format(metrics))
 
-
-        elif isinstance(metrics, list) or isinstance(metrics, numpy.ndarray) :
+        elif isinstance(metrics, list) or isinstance(metrics, numpy.ndarray):
             results = {}
 
             # RMSE
             is_rmse = False
-            if any( [ ('rmse' in m.lower() or 'root' in m.lower()) \
-                for m in metrics ]):
+            if any([("rmse" in m.lower() or "root" in m.lower()) for m in metrics]):
                 is_rmse = True
-                results['root_mean_squared_error'] = rmse
+                results["root_mean_squared_error"] = rmse
                 title += "\n"
                 title += "RMSE = {:.3f}".format(rmse)
 
             # Median Abs Error
             is_med_ae = False
-            if any( ['median' in m.lower() for m in metrics ]):
+            if any(["median" in m.lower() for m in metrics]):
                 is_med_ae = True
-                results['median_absolute_error'] = med_ae
+                results["median_absolute_error"] = med_ae
                 title += "\n"
                 title += "Median Abs Error = {:.3f}".format(med_ae)
 
             # Mean Abs Error
             is_mae = False
-            if any( ['mean' in m.lower() for m in metrics ]):
+            if any(["mean" in m.lower() for m in metrics]):
                 is_mae = True
-                results['mean_absolute_error'] = mae
+                results["mean_absolute_error"] = mae
                 title += "\n"
                 title += "Mean Abs Error = {:.3f}".format(mae)
 
             if all([not is_mae, not is_rmse, not is_med_ae]):
-                error = 'The provided metrics are not available.'
+                error = "The provided metrics are not available."
                 raise NotImplementedError(error)
 
     # Plotting
     fig, ax = plt.subplots(figsize=figure_size)
-    ax.plot(times, actual, color='red', label='Actual', 
-        alpha=0.8, lw = 3)
-    ax.plot(times, predicted,color='blue', label='Predicted', 
-        alpha=0.8, lw = 3)
+    ax.plot(times, actual, color="red", label="Actual", alpha=0.8, lw=3)
+    ax.plot(times, predicted, color="blue", label="Predicted", alpha=0.8, lw=3)
     plt.xlim(0, max(T))
 
     # Filling the areas between the Survival and Confidence Intervals curves
-    plt.fill_between(times, actual, actual_lower, 
-        label='Confidence Intervals - Lower', color='red', alpha =0.2)
-    plt.fill_between(times, actual, actual_upper, 
-        label='Confidence Intervals - Upper', color='red', alpha =0.2)
+    plt.fill_between(
+        times, actual, actual_lower, label="Confidence Intervals - Lower", color="red", alpha=0.2
+    )
+    plt.fill_between(
+        times, actual, actual_upper, label="Confidence Intervals - Upper", color="red", alpha=0.2
+    )
 
     # Finalizing the chart
-    plt.title(title, fontsize = 15)
-    plt.legend(fontsize = 15)
+    plt.title(title, fontsize=15)
+    plt.legend(fontsize=15)
     plt.show()
 
     return results
 
 
-def create_risk_groups(model, X, use_log = True, num_bins = 50, 
-                       figure_size = (20, 8), **kwargs):
+def create_risk_groups(model, X, use_log=True, num_bins=50, figure_size=(20, 8), **kwargs):
     """
-    Computing and displaying the histogram of the risk scores of the given 
-    model and test set X. If it is provided args, it will assign a color coding 
+    Computing and displaying the histogram of the risk scores of the given
+    model and test set X. If it is provided args, it will assign a color coding
     to the scores that are below and above the given thresholds.
 
     Parameters:
     -----------
-    
+
     * model : Pysurvival object
         Pysurvival model
 
     * X : array-like, shape=(n_samples, n_features)
         The input samples.
-    
+
     * use_log: boolean (default=True)
         Whether applying the log function to the risk score
-        
+
     * num_bins: int (default=50)
         The number of equal-width bins that will constitute the histogram
-        
+
     * figure_size: tuple of double (default= (16, 6))
-        width, height in inches representing the size of the chart 
+        width, height in inches representing the size of the chart
 
     * kwargs: dict (optional)
         kwargs = low_risk = {'lower_bound': 0, 'upper_bound': 20, 'color': 'red'},
                  high_risk = {'lower_bound': 20, 'upper_bound': 120, 'color': 'blue'}
             that define the risk group
-      
+
     """
 
     # Ensuring that the input data has the right format
@@ -452,25 +458,24 @@ def create_risk_groups(model, X, use_log = True, num_bins = 50,
     risk = model.predict_risk(X)
     if use_log:
         risk = np.log(risk)
-        
+
     # Displaying simple histogram
     if len(kwargs) == 0:
-        
         # Initializing the chart
         fig, ax1 = plt.subplots(figsize=figure_size)
         risk_groups = None
-    
+
     # Applying any color coding
     else:
         # Initializing the results
         risk_groups = {}
-        
+
         # Initializing the chart
         fig, ((ax1, ax2)) = plt.subplots(1, 2, figsize=figure_size)
-        
+
         # Displaying simple histogram with risk groups
         nums_per_bins, bins, patches = ax2.hist(risk, bins=num_bins)
-        ax2.set_title('Risk groups with colors', fontsize=15)
+        ax2.set_title("Risk groups with colors", fontsize=15)
 
         # Number of group definitions
         num_group_def = len(kwargs.values())
@@ -485,31 +490,28 @@ def create_risk_groups(model, X, use_log = True, num_bins = 50,
         # we need to check that the boundaries match the bins
         is_not_valid = 0
         for group_name, group_def in kwargs.items():
-
             # by ensuring that the bounds are not outside
             # the bins values
             min_bin, max_bin = min(bins), max(bins)
-            if (group_def['lower_bound'] < min_bin and \
-                group_def['upper_bound'] < min_bin) or \
-               (group_def['lower_bound'] > max_bin and \
-                group_def['upper_bound'] > max_bin) :
+            if (group_def["lower_bound"] < min_bin and group_def["upper_bound"] < min_bin) or (
+                group_def["lower_bound"] > max_bin and group_def["upper_bound"] > max_bin
+            ):
                 is_not_valid += 1
 
             # Extracting the bounds
-            bounds[group_name] = (group_def['lower_bound'], 
-                                  group_def['upper_bound'])
+            bounds[group_name] = (group_def["lower_bound"], group_def["upper_bound"])
 
             # Extracting the colors
-            colors_[group_name] = group_def['color']
+            colors_[group_name] = group_def["color"]
 
             # Creating index placeholders
             indexes[group_name] = []
-            group_names.append( group_name )
-            color_indv = group_def['color']
-            handles.append(Rectangle((0,0),1,1, color=color_indv, ec="k"))
+            group_names.append(group_name)
+            color_indv = group_def["color"]
+            handles.append(Rectangle((0, 0), 1, 1, color=color_indv, ec="k"))
 
-        if is_not_valid >= num_group_def :
-            error_msg =  "The boundaries definitions {} do not match"
+        if is_not_valid >= num_group_def:
+            error_msg = "The boundaries definitions {} do not match"
             error_msg += ", the values of the risk scores."
             error_msg = error_msg.format(list(bounds.values()))
             raise ValueError(error_msg)
@@ -519,87 +521,83 @@ def create_risk_groups(model, X, use_log = True, num_bins = 50,
         colored_patches = []
         bin_index = {}
         for i, bin_, patch_ in zip(range(num_bins), bins, patches):
-
             # Check if the bin belongs to this bound def
             for grp_name, bounds_ in bounds.items():
-
-                if bounds_[0] <= bin_ < bounds_[-1] :
+                if bounds_[0] <= bin_ < bounds_[-1]:
                     bin_index[i] = grp_name
-                    
+
                     # Extracting color
                     color_ = colors_[grp_name]
-                    if color_ not in colors.CSS4_COLORS :
-                        error_msg = '{} is not a valid color'
+                    if color_ not in colors.CSS4_COLORS:
+                        error_msg = "{} is not a valid color"
                         error_msg = error_msg.format(colors_[grp_name])
                         raise ValueError(error_msg)
-                        
-                    patch_.set_facecolor( color_ )
+
+                    patch_.set_facecolor(color_)
 
             # Saving the rectangles
             colored_patches.append(patch_)
 
         # Assigning each sample to its group
-        risk_bins = np.minimum(np.digitize(risk, bins, True), num_bins-1) 
+        risk_bins = np.minimum(np.digitize(risk, bins, True), num_bins - 1)
         for i, r in enumerate(risk_bins):
-
             # Extracting the right group_name
             group_name = bin_index[r]
             indexes[group_name].append(i)
-            
 
     # Displaying the original distribution
-    ax1.hist(risk, bins=num_bins, color = 'black', alpha=0.5)  
-    ax1.set_title('Risk Score Distribution', fontsize=15)
+    ax1.hist(risk, bins=num_bins, color="black", alpha=0.5)
+    ax1.set_title("Risk Score Distribution", fontsize=15)
 
     # Show everything
     plt.show()
-    
+
     # Returning results
     if risk_groups is not None:
         for group_name in group_names:
-            result = (colors_[group_name], indexes[group_name])            
+            result = (colors_[group_name], indexes[group_name])
             risk_groups[group_name] = result
 
     return risk_groups
 
 
-
-def correlation_matrix(df, figure_size=(12, 8), text_fontsize = 10):
-    """ Takes dataframe and display the correlations between features """
+def correlation_matrix(df, figure_size=(12, 8), text_fontsize=10):
+    """Takes dataframe and display the correlations between features"""
 
     # Computing correlations
     corr = df.corr()
-    
+
     # Display the correlations using heat map
     fig, ax1 = plt.subplots(figsize=figure_size)
-    cmap = cm.get_cmap('RdYlBu', 20) #'rainbow', 20)
-    cax = ax1.imshow(corr, interpolation="nearest", cmap=cmap, 
-                     vmax=1,vmin=-1)
-    
+    cmap = cm.get_cmap("RdYlBu", 20)  #'rainbow', 20)
+    cax = ax1.imshow(corr, interpolation="nearest", cmap=cmap, vmax=1, vmin=-1)
+
     # Add values in the cells
     for x in range(corr.shape[0]):
         for y in range(corr.shape[1]):
-            
             if x == y:
-                color = 'white'
+                color = "white"
             else:
-                color = 'black'
-                
-            plt.text(x , y , '%.2f' % corr.values[y, x], 
-                     horizontalalignment='center',
-                     verticalalignment='center',
-                     color = color,
-                     fontsize = text_fontsize,
-                     )
-    
+                color = "black"
+
+            plt.text(
+                x,
+                y,
+                "%.2f" % corr.values[y, x],
+                horizontalalignment="center",
+                verticalalignment="center",
+                color=color,
+                fontsize=text_fontsize,
+            )
+
     # Reformat the x/y axis
-    labels=df.columns
+    labels = df.columns
     ax1.set_xticks(range(len(labels)))
-    ax1.set_xticklabels(labels,fontsize=16)
+    ax1.set_xticklabels(labels, fontsize=16)
     ax1.set_yticks(range(len(labels)))
-    ax1.set_yticklabels(labels,fontsize=16)
+    ax1.set_yticklabels(labels, fontsize=16)
     plt.xticks(rotation=80)
-    
+
     # Add colorbar, specify tick locations to match desired ticklabels
     fig.colorbar(cax, ticks=np.arange(-1.1, 1.1, 0.1))
     plt.show()

--- a/pysurvival/utils/metrics.py
+++ b/pysurvival/utils/metrics.py
@@ -1,26 +1,23 @@
 from __future__ import absolute_import
+
 import numpy as np
-import pandas as pd
-import scipy
-from sklearn.metrics import mean_absolute_error, mean_squared_error
-from sklearn.metrics import median_absolute_error
-from pysurvival.models.non_parametric import KaplanMeierModel
-from pysurvival.utils._metrics import _concordance_index
-from pysurvival.utils._metrics import _brier_score, _timeROC
+from sklearn.metrics import mean_absolute_error, mean_squared_error, median_absolute_error
+
 from pysurvival import utils
+from pysurvival.models.non_parametric import KaplanMeierModel
+from pysurvival.utils._metrics import _brier_score, _concordance_index
 
 
-def concordance_index(model, X, T, E, include_ties = True, 
-    additional_results=False, **kwargs):
-    """ 
+def concordance_index(model, X, T, E, include_ties=True, additional_results=False, **kwargs):
+    """
     Computing the C-index based on *On The C-Statistics For Evaluating Overall
     Adequacy Of Risk Prediction Procedures With Censored Survival Data* and
     *Estimating the Concordance Probability in a Survival Analysis
-    with a Discrete Number of Risk Groups* and *Concordance for Survival 
+    with a Discrete Number of Risk Groups* and *Concordance for Survival
     Time Data: Fixed and Time-Dependent Covariates and Possible Ties in
-    Predictor and Time 
+    Predictor and Time
 
-    Similarly to the AUC, C-index = 1 corresponds to the best model 
+    Similarly to the AUC, C-index = 1 corresponds to the best model
     prediction, and C-index = 0.5 represents a random prediction.
 
     Parameters:
@@ -31,10 +28,10 @@ def concordance_index(model, X, T, E, include_ties = True,
     * X : array-like, shape=(n_samples, n_features)
         The input samples.
 
-    * E : array-like, shape = [n_samples] 
+    * E : array-like, shape = [n_samples]
         The Event indicator array such that E = 1. if the event occured
         E = 0. if censoring occured
-    
+
     * include_ties: bool (default=True)
         Specifies whether ties in risk score are included in calculations
 
@@ -53,14 +50,14 @@ def concordance_index(model, X, T, E, include_ties = True,
                 results[0] = C-index;
                 results[1] = nb_pairs;
                 results[2] = nb_concordant_pairs;
-                    
+
     Example:
     --------
 
 
     """
 
-    # Checking the format of the data 
+    # Checking the format of the data
     risk = model.predict_risk(X, **kwargs)
     risk, T, E = utils.check_data(risk, T, E)
 
@@ -79,30 +76,30 @@ def concordance_index(model, X, T, E, include_ties = True,
         return results
 
 
-def c_index(model, X, T, E, include_ties = True, additional_results=False):
+def c_index(model, X, T, E, include_ties=True, additional_results=False):
     return concordance_index(model, X, T, E, include_ties, additional_results)
 
 
 def brier_score(model, X, T, E, t_max=None, use_mean_point=True, **kwargs):
-    """ 
+    """
     Computing the Brier score at all times t such that t <= t_max;
-    it represents the average squared distances between 
+    it represents the average squared distances between
     the observed survival status and the predicted
     survival probability.
 
     In the case of right censoring, it is necessary to adjust
-    the score by weighting the squared distances to 
-    avoid bias. It can be achieved by using 
+    the score by weighting the squared distances to
+    avoid bias. It can be achieved by using
     the inverse probability of censoring weights method (IPCW),
     (proposed by Graf et al. 1999; Gerds and Schumacher 2006)
     by using the estimator of the conditional survival function
     of the censoring times calculated using the Kaplan-Meier method,
     such that :
-    BS(t) = 1/N*( W_1(t)*(Y_1(t) - S_1(t))^2 + ... + 
+    BS(t) = 1/N*( W_1(t)*(Y_1(t) - S_1(t))^2 + ... +
                   W_N(t)*(Y_N(t) - S_N(t))^2)
 
-    In terms of benchmarks, a useful model will have a Brier score below 
-    0.25. Indeed, it is easy to see that if for all i in [1,N], 
+    In terms of benchmarks, a useful model will have a Brier score below
+    0.25. Indeed, it is easy to see that if for all i in [1,N],
     if S(t, xi) = 0.5, then BS(t) = 0.25.
 
     Parameters:
@@ -113,31 +110,31 @@ def brier_score(model, X, T, E, t_max=None, use_mean_point=True, **kwargs):
     * X : array-like, shape=(n_samples, n_features)
         The input samples.
 
-    * T : array-like, shape = [n_samples] 
+    * T : array-like, shape = [n_samples]
         The target values describing when the event of interest or censoring
         occured
 
-    * E : array-like, shape = [n_samples] 
+    * E : array-like, shape = [n_samples]
         The Event indicator array such that E = 1. if the event occured
         E = 0. if censoring occured
-    
-    * t_max: float 
-        Maximal time for estimating the prediction error curves. 
+
+    * t_max: float
+        Maximal time for estimating the prediction error curves.
         If missing the largest value of the response variable is used.
 
     Returns:
     --------
         * (times, brier_scores):tuple of arrays
-            -times represents the time axis at which the brier scores were 
+            -times represents the time axis at which the brier scores were
               computed
             - brier_scores represents the values of the brier scores
-                    
+
     Example:
     --------
 
 
     """
-    # Checking the format of the data 
+    # Checking the format of the data
     T, E = utils.check_data(T, E)
 
     # computing the Survival function
@@ -153,21 +150,20 @@ def brier_score(model, X, T, E, t_max=None, use_mean_point=True, **kwargs):
     T = T[order]
     E = E[order]
 
-    if t_max is None or t_max <= 0.:
+    if t_max is None or t_max <= 0.0:
         t_max = max(T)
 
     # Calculating the brier scores at each t <= t_max
-    results = _brier_score(Survival, T, E, t_max, times, time_buckets,
-        use_mean_point)
-    times = results[0] 
-    brier_scores = results[1] 
+    results = _brier_score(Survival, T, E, t_max, times, time_buckets, use_mean_point)
+    times = results[0]
+    brier_scores = results[1]
 
     return (times, brier_scores)
 
 
 def integrated_brier_score(model, X, T, E, t_max=None, use_mean_point=True):
-    """ The Integrated Brier Score (IBS) provides an overall calculation of 
-        the model performance at all available times.
+    """The Integrated Brier Score (IBS) provides an overall calculation of
+    the model performance at all available times.
     """
 
     # Computing the brier scores
@@ -180,21 +176,28 @@ def integrated_brier_score(model, X, T, E, t_max=None, use_mean_point=True):
         t_max = min(t_max, max(times))
 
     # Computing the IBS
-    ibs_value = np.trapz(brier_scores, times)/t_max 
+    ibs_value = np.trapz(brier_scores, times) / t_max
 
     return ibs_value
 
 
-def ibs(model, X, T, E, t_max=None, use_mean_point = True):
+def ibs(model, X, T, E, t_max=None, use_mean_point=True):
     return integrated_brier_score(model, X, T, E, t_max, use_mean_point)
 
 
-
-
-def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,  
-    figsize=(16, 6), metrics = ['rmse', 'mean', 'median'], **kwargs):
+def compare_to_actual(
+    model,
+    X,
+    T,
+    E,
+    times=None,
+    is_at_risk=False,
+    figsize=(16, 6),
+    metrics=["rmse", "mean", "median"],
+    **kwargs
+):
     """
-    Comparing the actual and predicted number of units at risk and units 
+    Comparing the actual and predicted number of units at risk and units
     experiencing an event at each time t.
 
     Parameters:
@@ -205,11 +208,11 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     * X : array-like, shape=(n_samples, n_features)
         The input samples.
 
-    * T : array-like, shape = [n_samples] 
+    * T : array-like, shape = [n_samples]
         The target values describing when the event of interest or censoring
         occured
 
-    * E : array-like, shape = [n_samples] 
+    * E : array-like, shape = [n_samples]
         The Event indicator array such that E = 1. if the event occured
         E = 0. if censoring occured
 
@@ -221,7 +224,7 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
         or the Expected number of units experiencing the events.
 
     * figure_size: tuple of double (default= (16, 6))
-        width, height in inches representing the size of the chart 
+        width, height in inches representing the size of the chart
 
     * metrics: str or list of str (default='all')
         Indicates the performance metrics to compute:
@@ -237,7 +240,7 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     Returns:
     --------
     * results: float or dict
-        Performance metrics   
+        Performance metrics
 
     """
 
@@ -260,32 +263,31 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
     actual_lower = []
     predicted = []
     if is_at_risk:
-        model_predicted =  np.sum(model.predict_survival(X, **kwargs), 0)
+        model_predicted = np.sum(model.predict_survival(X, **kwargs), 0)
 
         for t in times:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in model.time_buckets]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in model.time_buckets]
             index = np.argmin(min_index)
-            actual.append(N*kmf.predict_survival(t))
-            actual_upper.append(N*kmf.predict_survival_upper(t))
-            actual_lower.append(N*kmf.predict_survival_lower(t))
-            predicted.append( model_predicted[index] )
+            actual.append(N * kmf.predict_survival(t))
+            actual_upper.append(N * kmf.predict_survival_upper(t))
+            actual_lower.append(N * kmf.predict_survival_lower(t))
+            predicted.append(model_predicted[index])
 
     else:
-        model_predicted =  np.sum(model.predict_density(X, **kwargs), 0)
+        model_predicted = np.sum(model.predict_density(X, **kwargs), 0)
 
         for t in times:
-            min_index = [ abs(a_j_1-t) for (a_j_1, a_j) in model.time_buckets]
+            min_index = [abs(a_j_1 - t) for (a_j_1, a_j) in model.time_buckets]
             index = np.argmin(min_index)
-            actual.append(N*kmf.predict_density(t))
+            actual.append(N * kmf.predict_density(t))
             h = kmf.predict_hazard(t)
-            actual_upper.append(N*kmf.predict_survival_upper(t)*h)
-            actual_lower.append(N*kmf.predict_survival_lower(t)*h)
-            predicted.append( model_predicted[index] )
+            actual_upper.append(N * kmf.predict_survival_upper(t) * h)
+            actual_lower.append(N * kmf.predict_survival_lower(t) * h)
+            predicted.append(model_predicted[index])
 
     # Computing the performance metrics
     results = None
     if metrics is not None:
-
         # RMSE
         rmse = np.sqrt(mean_squared_error(actual, predicted))
 
@@ -295,62 +297,57 @@ def compare_to_actual(model, X, T, E, times = None, is_at_risk = False,
         # Mean Abs Error
         mae = mean_absolute_error(actual, predicted)
 
-
-        if isinstance(metrics, str) :
-
+        if isinstance(metrics, str):
             # RMSE
-            if 'rmse' in metrics.lower() or 'root' in metrics.lower():
+            if "rmse" in metrics.lower() or "root" in metrics.lower():
                 results = rmse
                 # title += "\n"
                 # title += "RMSE = {:.3f}".format(rmse)
 
             # Median Abs Error
-            elif 'median' in metrics.lower() :
+            elif "median" in metrics.lower():
                 results = med_ae
                 # title += "\n"
                 # title += "Median Abs Error = {:.3f}".format(med_ae)
 
             # Mean Abs Error
-            elif 'mean' in metrics.lower() :
+            elif "mean" in metrics.lower():
                 results = mae
                 # title += "\n"
                 # title += "Mean Abs Error = {:.3f}".format(mae)
 
             else:
-                raise NotImplementedError('{} is not a valid metric function.'
-                .format(metrics))
+                raise NotImplementedError("{} is not a valid metric function.".format(metrics))
 
-
-        elif isinstance(metrics, list) or isinstance(metrics, numpy.ndarray) :
+        elif isinstance(metrics, list) or isinstance(metrics, numpy.ndarray):
             results = {}
 
             # RMSE
             is_rmse = False
-            if any( [ ('rmse' in m.lower() or 'root' in m.lower()) \
-                for m in metrics ]):
+            if any([("rmse" in m.lower() or "root" in m.lower()) for m in metrics]):
                 is_rmse = True
-                results['root_mean_squared_error'] = rmse
+                results["root_mean_squared_error"] = rmse
                 # title += "\n"
                 # title += "RMSE = {:.3f}".format(rmse)
 
             # Median Abs Error
             is_med_ae = False
-            if any( ['median' in m.lower() for m in metrics ]):
+            if any(["median" in m.lower() for m in metrics]):
                 is_med_ae = True
-                results['median_absolute_error'] = rmse
+                results["median_absolute_error"] = rmse
                 # title += "\n"
                 # title += "Median Abs Error = {:.3f}".format(med_ae)
 
             # Mean Abs Error
             is_mae = False
-            if any( ['mean' in m.lower() for m in metrics ]):
+            if any(["mean" in m.lower() for m in metrics]):
                 is_mae = True
-                results['mean_absolute_error'] = rmse
+                results["mean_absolute_error"] = rmse
                 # title += "\n"
                 # title += "Mean Abs Error = {:.3f}".format(mae)
 
             if all([not is_mae, not is_rmse, not is_med_ae]):
-                error = 'The provided metrics are not available.'
+                error = "The provided metrics are not available."
                 raise NotImplementedError(error)
-                
+
     return results

--- a/pysurvival/utils/neural_networks.py
+++ b/pysurvival/utils/neural_networks.py
@@ -1,200 +1,215 @@
-import torch 
-import torch.nn as nn
 import numpy as np
+import torch
+import torch.nn as nn
+
 import pysurvival.utils.optimization as opt
+
 
 # --------------------------- Activation Functions --------------------------- #
 class Swish(nn.Module):
     def forward(self, x):
         return x * torch.sigmoid(x)
 
+
 class Gaussian(nn.Module):
     def forward(self, x):
-        return torch.exp(- x*x/2.)
-    
+        return torch.exp(-x * x / 2.0)
+
+
 class Atan(nn.Module):
     def forward(self, x):
         return torch.atan(x)
 
+
 class InverseSqrt(nn.Module):
-    def forward(self, x, alpha=1.):
-        return x/torch.sqrt(1.+alpha*x*x)
-    
+    def forward(self, x, alpha=1.0):
+        return x / torch.sqrt(1.0 + alpha * x * x)
+
+
 class Sinc(nn.Module):
     def forward(self, x, epsilon=1e-9):
-        return torch.sin(x+epsilon)/(x+epsilon)
-    
+        return torch.sin(x + epsilon) / (x + epsilon)
+
+
 class SinReLU(nn.Module):
     def forward(self, x):
-        return torch.sin(x)+torch.relu(x)
+        return torch.sin(x) + torch.relu(x)
+
 
 class CosReLU(nn.Module):
     def forward(self, x):
-        return torch.cos(x)+torch.relu(x)
+        return torch.cos(x) + torch.relu(x)
+
 
 class LeCunTanh(nn.Module):
     def forward(self, x):
-        return 1.7159*torch.tanh(2./3*x)
-           
+        return 1.7159 * torch.tanh(2.0 / 3 * x)
+
+
 class LogLog(nn.Module):
     def forward(self, x):
-        return 1.-torch.exp(-torch.exp(x))
-    
+        return 1.0 - torch.exp(-torch.exp(x))
+
+
 class BipolarSigmoid(nn.Module):
     def forward(self, x):
-        return (1.-torch.exp(-x))/(1.+torch.exp(-x)) 
-    
+        return (1.0 - torch.exp(-x)) / (1.0 + torch.exp(-x))
+
+
 class BentIdentity(nn.Module):
-    def forward(self, x, alpha=1.):
-        return x + (torch.sqrt(1.+ x*x)- 1.)/2.
+    def forward(self, x, alpha=1.0):
+        return x + (torch.sqrt(1.0 + x * x) - 1.0) / 2.0
+
 
 class Identity(nn.Module):
     def forward(self, x):
-        return x 
+        return x
+
 
 class Softmax(nn.Module):
     def forward(self, x):
         y = torch.exp(x)
-        return y/torch.sum(y, dim=0)
-    
-def activation_function(activation, alpha=1., return_text=False):
-    """ Returns the activation function object used by the network """
-    
-    if activation.lower() == 'atan':
-        if return_text :
-            return 'Atan'
+        return y / torch.sum(y, dim=0)
+
+
+def activation_function(activation, alpha=1.0, return_text=False):
+    """Returns the activation function object used by the network"""
+
+    if activation.lower() == "atan":
+        if return_text:
+            return "Atan"
         else:
             return Atan()
-    
-    elif activation.lower().startswith('bent'):
-        if return_text :
-            return 'BentIdentity'
+
+    elif activation.lower().startswith("bent"):
+        if return_text:
+            return "BentIdentity"
         else:
             return BentIdentity()
 
-    elif activation.lower().startswith('bipolar'):
-        if return_text :
-            return 'BipolarSigmoid'
+    elif activation.lower().startswith("bipolar"):
+        if return_text:
+            return "BipolarSigmoid"
         else:
             return BipolarSigmoid()
-    
-    elif activation.lower().startswith('cosrelu'):
-        if return_text :
-            return 'CosReLU'
+
+    elif activation.lower().startswith("cosrelu"):
+        if return_text:
+            return "CosReLU"
         else:
-            return CosReLU()    
-    
-    elif activation.lower() == 'elu':
-        if return_text :
-            return 'ELU'
+            return CosReLU()
+
+    elif activation.lower() == "elu":
+        if return_text:
+            return "ELU"
         else:
             return nn.ELU(alpha=alpha)
-    
-    elif activation.lower() == 'gaussian':
-        if return_text :
-            return 'Gaussian'
+
+    elif activation.lower() == "gaussian":
+        if return_text:
+            return "Gaussian"
         else:
             return Gaussian()
-        
-    elif activation.lower() == 'hardtanh':
-        if return_text :
-            return 'Hardtanh'
+
+    elif activation.lower() == "hardtanh":
+        if return_text:
+            return "Hardtanh"
         else:
             return nn.Hardtanh()
-    
-    elif activation.lower() == 'identity':
-        if return_text :
-            return 'Identity'
+
+    elif activation.lower() == "identity":
+        if return_text:
+            return "Identity"
         else:
             return Identity()
-    
-    elif activation.lower().startswith('inverse'):
-        if return_text :
-            return 'InverseSqrt'
+
+    elif activation.lower().startswith("inverse"):
+        if return_text:
+            return "InverseSqrt"
         else:
-            return InverseSqrt()    
-        
-    elif activation.lower() == 'leakyrelu':
-        if return_text :
-            return 'LeakyReLU'
+            return InverseSqrt()
+
+    elif activation.lower() == "leakyrelu":
+        if return_text:
+            return "LeakyReLU"
         else:
             return nn.LeakyReLU()
-    
-    elif activation.lower().startswith('lecun'):
-        if return_text :
-            return 'LeCunTanh'
+
+    elif activation.lower().startswith("lecun"):
+        if return_text:
+            return "LeCunTanh"
         else:
-            return LeCunTanh()    
-    
-    elif activation.lower() == 'loglog':
-        if return_text :
-            return 'LogLog'
+            return LeCunTanh()
+
+    elif activation.lower() == "loglog":
+        if return_text:
+            return "LogLog"
         else:
             return LogLog()
-    
-    elif activation.lower() == 'logsigmoid':
-        if return_text :
-            return 'LogSigmoid'
+
+    elif activation.lower() == "logsigmoid":
+        if return_text:
+            return "LogSigmoid"
         else:
-            return nn.LogSigmoid()    
-    
-    elif activation.lower() == 'relu':
-        if return_text :
-            return 'ReLU'
+            return nn.LogSigmoid()
+
+    elif activation.lower() == "relu":
+        if return_text:
+            return "ReLU"
         else:
             return nn.ReLU()
-        
-    elif activation.lower() == 'selu':
-        if return_text :
-            return 'SELU'
+
+    elif activation.lower() == "selu":
+        if return_text:
+            return "SELU"
         else:
             return nn.SELU()
-    
-    elif activation.lower() == 'sigmoid':
-        if return_text :
-            return 'Sigmoid'
+
+    elif activation.lower() == "sigmoid":
+        if return_text:
+            return "Sigmoid"
         else:
             return nn.Sigmoid()
-    
-    elif activation.lower() == 'sinc':
-        if return_text :
-            return 'Sinc'
+
+    elif activation.lower() == "sinc":
+        if return_text:
+            return "Sinc"
         else:
             return Sinc()
-    
-    elif activation.lower().startswith('sinrelu'):
-        if return_text :
-            return 'SinReLU'
+
+    elif activation.lower().startswith("sinrelu"):
+        if return_text:
+            return "SinReLU"
         else:
-            return SinReLU()    
-    
-    elif activation.lower() == 'softmax':
-        if return_text :
-            return 'Softmax'
+            return SinReLU()
+
+    elif activation.lower() == "softmax":
+        if return_text:
+            return "Softmax"
         else:
             return Softmax()
-        
-    elif activation.lower() == 'softplus':
-        if return_text :
-            return 'Softplus'
+
+    elif activation.lower() == "softplus":
+        if return_text:
+            return "Softplus"
         else:
             return nn.Softplus()
-        
-    elif activation.lower() == 'softsign':
-        if return_text :
-            return 'Softsign'
+
+    elif activation.lower() == "softsign":
+        if return_text:
+            return "Softsign"
         else:
             return nn.Softsign()
-    
-    elif activation.lower() == 'swish':
-        if return_text :
-            return 'Swish'
+
+    elif activation.lower() == "swish":
+        if return_text:
+            return "Swish"
         else:
             return Swish()
-        
-    elif activation.lower() == 'tanh':
-        if return_text :
-            return 'Tanh'
+
+    elif activation.lower() == "tanh":
+        if return_text:
+            return "Tanh"
         else:
             return nn.Tanh()
 
@@ -203,44 +218,41 @@ def activation_function(activation, alpha=1., return_text=False):
         raise NotImplementedError(error)
 
 
-
 def check_mlp_structure(structure):
-    """ Checking that the given MLP structure is valid """
-
+    """Checking that the given MLP structure is valid"""
 
     # Checking if structure is dict
     if isinstance(structure, dict):
         structure = [structure]
 
-    # Checking the keys 
+    # Checking the keys
     results = []
     for inner_structure in structure:
-
         # Checking the validity of activation
-        activation = inner_structure.get('activation')
+        activation = inner_structure.get("activation")
         if activation is None:
-            error = 'An activation function needs to be provided ' 
-            error +='using the key "activation"'
+            error = "An activation function needs to be provided "
+            error += 'using the key "activation"'
             raise KeyError(error)
 
         else:
             activation = activation_function(activation, return_text=True)
-            inner_structure['activation'] = activation
+            inner_structure["activation"] = activation
 
         # Checking the validity of num_units
-        num_units = inner_structure.get('num_units')
+        num_units = inner_structure.get("num_units")
         if num_units is None:
-            error = 'The number of hidden units needs to be provided ' 
-            error +='using the key "num_units"'
+            error = "The number of hidden units needs to be provided "
+            error += 'using the key "num_units"'
             raise KeyError(error)
 
         else:
             if not isinstance(num_units, int):
-                error = 'num_units in {} needs to be a integer'
+                error = "num_units in {} needs to be a integer"
                 error = error.format(inner_structure)
                 raise TypeError(error)
             else:
-                inner_structure['num_units'] = num_units
+                inner_structure["num_units"] = num_units
 
         results.append(inner_structure)
 
@@ -249,7 +261,7 @@ def check_mlp_structure(structure):
 
 # ----------------------------- MLP Object ----------------------------- #
 class NeuralNet(nn.Module):
-    """ Defines a Multilayer Perceptron (MLP) that consists in 
+    """Defines a Multilayer Perceptron (MLP) that consists in
         * an input layer,
         * at least one fully connected neural layer (or hidden layer)
         * and an output layer
@@ -263,8 +275,8 @@ class NeuralNet(nn.Module):
     * structure: None or list of dictionnaries
         Provides the structure of the MLP built within the N-MTLR
         If None, then the model becomes the Linear MTLR
-        ex: structure = [ {'activation': 'relu', 'num_units': 128}, 
-                          {'activation': 'tanh', 'num_units': 128}, ] 
+        ex: structure = [ {'activation': 'relu', 'num_units': 128},
+                          {'activation': 'tanh', 'num_units': 128}, ]
         Here are the possible activation functions:
             * Atan
             * BentIdentity
@@ -292,7 +304,7 @@ class NeuralNet(nn.Module):
     * init_method: str
         Defines the type of initializer to use
     * dropout: double (default=None)
-        Randomly sets a fraction rate of input units to 0 
+        Randomly sets a fraction rate of input units to 0
         at each update during training time, which helps prevent overfitting.
     * batch_normalization: bool (default=True)
         Applying Batch Normalization or not
@@ -302,21 +314,29 @@ class NeuralNet(nn.Module):
 
     Note about Dropout and Batch Normalization:
     ------------------------------------------
-    As a rule, the dropout Layer and Batch Normalization (BN) shouldn't be used 
+    As a rule, the dropout Layer and Batch Normalization (BN) shouldn't be used
     together according to : https://arxiv.org/pdf/1801.05134.pdf
 
     * Dropout is used to Prevent Neural Networks from Overfitting
-      should appears after the activation according to : 
+      should appears after the activation according to :
       https://www.cs.toronto.edu/~hinton/absps/JMLRdropout.pdf
 
-    * Batch Normalization can Accelerate Deep Network Training by Reducing 
-      Internal Covariate Shift BN should appear after Fully connected but 
+    * Batch Normalization can Accelerate Deep Network Training by Reducing
+      Internal Covariate Shift BN should appear after Fully connected but
       before activation according to : https://arxiv.org/pdf/1502.03167.pdf
 
-    """    
-    def __init__(self, input_size, output_size, structure, init_method
-        , dropout=None, batch_normalization = True, bn_and_droupout = False):
+    """
 
+    def __init__(
+        self,
+        input_size,
+        output_size,
+        structure,
+        init_method,
+        dropout=None,
+        batch_normalization=True,
+        bn_and_droupout=False,
+    ):
         # Initializing the model
         super(NeuralNet, self).__init__()
 
@@ -324,94 +344,82 @@ class NeuralNet(nn.Module):
         self.layers = []
 
         if structure is not None and structure != []:
-
             # Checking if structure is dict
             if isinstance(structure, dict):
                 structure = [structure]
 
             # Building the hidden layers
             for hidden in structure:
-
-                # Extracting the hidden layer parameters 
-                hidden_size = int(hidden.get('num_units'))
-                activation  = hidden.get('activation')
-                alpha       = hidden.get('alpha')
+                # Extracting the hidden layer parameters
+                hidden_size = int(hidden.get("num_units"))
+                activation = hidden.get("activation")
+                alpha = hidden.get("alpha")
 
                 # Fully connected layer
-                fully_conn = nn.Linear(input_size, hidden_size) 
-                fully_conn.weight = opt.initialization(init_method, 
-                    fully_conn.weight)
-                fully_conn.bias = opt.initialization(init_method, 
-                    fully_conn.bias)
-                self.layers.append( fully_conn )
-                
+                fully_conn = nn.Linear(input_size, hidden_size)
+                fully_conn.weight = opt.initialization(init_method, fully_conn.weight)
+                fully_conn.bias = opt.initialization(init_method, fully_conn.bias)
+                self.layers.append(fully_conn)
+
                 if not bn_and_droupout:
                     # Batch Normalization
                     if batch_normalization:
-                        self.layers.append( torch.nn.BatchNorm1d(hidden_size) )
+                        self.layers.append(torch.nn.BatchNorm1d(hidden_size))
 
                     # Activation
-                    self.layers.append( activation_function(activation, 
-                        alpha=alpha) )
-                    
+                    self.layers.append(activation_function(activation, alpha=alpha))
+
                     # Dropout
-                    if (dropout is not None or 0. < dropout <= 1.) and \
-                    not batch_normalization :
-                        self.layers.append( torch.nn.Dropout(dropout) )
+                    if (dropout is not None or 0.0 < dropout <= 1.0) and not batch_normalization:
+                        self.layers.append(torch.nn.Dropout(dropout))
 
                 else:
                     # Batch Normalization
                     if batch_normalization:
-                        self.layers.append( torch.nn.BatchNorm1d(hidden_size) )
+                        self.layers.append(torch.nn.BatchNorm1d(hidden_size))
 
                     # Activation
-                    self.layers.append( activation_function(activation, 
-                        alpha=alpha) )
-                    
+                    self.layers.append(activation_function(activation, alpha=alpha))
+
                     # Dropout
-                    if (dropout is not None or 0. < dropout <= 1.) :
-                        self.layers.append( torch.nn.Dropout(dropout) )
+                    if dropout is not None or 0.0 < dropout <= 1.0:
+                        self.layers.append(torch.nn.Dropout(dropout))
 
                 # Next layer
                 input_size = hidden_size
 
         # Fully connected last layer
-        fully_conn = nn.Linear(input_size, output_size) 
+        fully_conn = nn.Linear(input_size, output_size)
         fully_conn.weight = opt.initialization(init_method, fully_conn.weight)
         fully_conn.bias = opt.initialization(init_method, fully_conn.bias)
-        self.layers.append( fully_conn )
+        self.layers.append(fully_conn)
 
-        # Putting the model together 
+        # Putting the model together
         self.model = nn.Sequential(*self.layers).train()
 
-
     def forward(self, x):
-
         out = self.model(x)
         return out
 
 
-        
 class ParametricNet(torch.nn.Module):
-    """ Underlying Pytorch model powering the Parametric models """
+    """Underlying Pytorch model powering the Parametric models"""
 
-    def __init__(self, num_features, init_method, init_alpha=1., 
-        is_beta_used = True):
+    def __init__(self, num_features, init_method, init_alpha=1.0, is_beta_used=True):
         super(ParametricNet, self).__init__()
 
         # weights
-        W = torch.randn(num_features, 1) 
+        W = torch.randn(num_features, 1)
         self.W = opt.initialization(init_method, W)
 
-        one =  torch.FloatTensor(np.array([1]))/init_alpha
-        self.alpha = torch.nn.Parameter( one ) 
+        one = torch.FloatTensor(np.array([1])) / init_alpha
+        self.alpha = torch.nn.Parameter(one)
 
         self.is_beta_used = is_beta_used
         if self.is_beta_used:
-            one =  torch.FloatTensor(np.array([1.001]))/init_alpha
-            self.beta = torch.nn.Parameter( one ) 
+            one = torch.FloatTensor(np.array([1.001])) / init_alpha
+            self.beta = torch.nn.Parameter(one)
 
     def forward(self, x):
-        score =  self.alpha*torch.exp(torch.matmul(x, self.W))
+        score = self.alpha * torch.exp(torch.matmul(x, self.W))
         return score
-

--- a/pysurvival/utils/optimization.py
+++ b/pysurvival/utils/optimization.py
@@ -1,20 +1,21 @@
-import numpy as np
-import torch
-import torch.nn as nn
-import progressbar
-import time
 import copy
 
+import numpy as np
+import progressbar
+import torch
+import torch.nn as nn
+
+
 def initialization(init_method, W, is_tensor=True):
-    """ Initializes the provided tensor. 
-    
+    """Initializes the provided tensor.
+
     Parameters:
     -----------
 
     * init_method : str (default = 'glorot_uniform')
         Initialization method to use. Here are the possible options:
-            * 'glorot_uniform': Glorot/Xavier uniform initializer, 
-                Glorot & Bengio, AISTATS 2010 
+            * 'glorot_uniform': Glorot/Xavier uniform initializer,
+                Glorot & Bengio, AISTATS 2010
                 http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
             * 'he_uniform': He uniform variance scaling initializer
                He et al., http://arxiv.org/abs/1502.01852
@@ -29,7 +30,7 @@ def initialization(init_method, W, is_tensor=True):
     * W: torch.Tensor
         Corresponds to the Torch tensor
 
-      """
+    """
 
     # Checking the dimensions
     is_one_dim = False
@@ -39,46 +40,42 @@ def initialization(init_method, W, is_tensor=True):
         W = torch.FloatTensor(W)
 
     # Creating a column vector if one dimensional tensor
-    if len(W.shape)==1:
+    if len(W.shape) == 1:
         is_one_dim = True
         W = torch.reshape(W, (1, -1))
 
     # Initializing the weights
-    if init_method.lower() == 'uniform':
+    if init_method.lower() == "uniform":
         W = nn.init.uniform_(W)
-        
-    elif init_method.lower() == 'normal':
-        W = nn.init.normal_(W)
-        
-    elif init_method.lower().startswith('one'):
-        W = nn.init.ones_(W)        
-        
-    elif init_method.lower().startswith('zero'):
-        W = nn.init.zeros_(W)   
 
-    elif init_method.lower().startswith('ortho'):
-        W = nn.init.orthogonal_(W) 
-        
-    elif init_method.lower().startswith('glorot') or \
-    init_method.lower().startswith('xav'):
-        
-        if init_method.lower().endswith('uniform'):
+    elif init_method.lower() == "normal":
+        W = nn.init.normal_(W)
+
+    elif init_method.lower().startswith("one"):
+        W = nn.init.ones_(W)
+
+    elif init_method.lower().startswith("zero"):
+        W = nn.init.zeros_(W)
+
+    elif init_method.lower().startswith("ortho"):
+        W = nn.init.orthogonal_(W)
+
+    elif init_method.lower().startswith("glorot") or init_method.lower().startswith("xav"):
+        if init_method.lower().endswith("uniform"):
             W = nn.init.xavier_uniform_(W)
-        elif init_method.lower().endswith('normal'):
+        elif init_method.lower().endswith("normal"):
             W = nn.init.xavier_normal_(W)
-            
-    elif init_method.lower().startswith('he') or \
-    init_method.lower().startswith('kaiming'):
-        
-        if init_method.lower().endswith('uniform'):
+
+    elif init_method.lower().startswith("he") or init_method.lower().startswith("kaiming"):
+        if init_method.lower().endswith("uniform"):
             W = nn.init.kaiming_uniform_(W)
-        elif init_method.lower().endswith('normal'):
+        elif init_method.lower().endswith("normal"):
             W = nn.init.kaiming_normal_(W)
 
     else:
         error = " {} isn't implemented".format(init_method)
         raise NotImplementedError(error)
-        
+
     # Returning a PyTorch tensor
     if is_tensor:
         if is_one_dim:
@@ -91,15 +88,21 @@ def initialization(init_method, W, is_tensor=True):
         if is_one_dim:
             return W.data.numpy().flatten()
         else:
-            return W.data.numpy()      
-        
-        
+            return W.data.numpy()
 
 
-def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000, 
-               verbose = True, num_workers = 0, **kargs):
-    """ 
-    Providing the schema of the iterative method for optimizing a 
+def optimize(
+    loss_function,
+    model,
+    optimizer_str,
+    lr=1e-4,
+    nb_epochs=1000,
+    verbose=True,
+    num_workers=0,
+    **kargs
+):
+    """
+    Providing the schema of the iterative method for optimizing a
     differentiable objective function for models that use gradient centric
     schemas (a.k.a order 1 optimization)
 
@@ -111,7 +114,7 @@ def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000,
         * model: torch object
             Actual model to optimize
 
-        * optimizer_str: str 
+        * optimizer_str: str
             Defines the type of optimizer to use. Here are the possible options:
                 - adadelta
                 - adagrad
@@ -133,49 +136,47 @@ def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000,
 
     # Choosing an optimizer
     W = model.parameters()
-    if optimizer_str.lower() == 'adadelta':
-        optimizer = torch.optim.Adadelta(W, lr=lr) 
-        
-    elif optimizer_str.lower() == 'adagrad':
-        optimizer = torch.optim.Adagrad(W, lr=lr) 
-    
-    elif optimizer_str.lower() == 'adam':
-        optimizer = torch.optim.Adam(W, lr=lr) 
-    
-    elif optimizer_str.lower() == 'adamax':
-        optimizer = torch.optim.Adamax(W, lr=lr)     
-    
-    elif optimizer_str.lower() == 'rmsprop':
-        optimizer = torch.optim.RMSprop(W, lr=lr)  
-    
-    elif optimizer_str.lower() == 'sparseadam':
-        optimizer = torch.optim.SparseAdam(W, lr=lr)  
-    
-    elif optimizer_str.lower() == 'sgd':
-        optimizer = torch.optim.SGD(W, lr=lr)  
+    if optimizer_str.lower() == "adadelta":
+        optimizer = torch.optim.Adadelta(W, lr=lr)
 
-    elif optimizer_str.lower() == 'lbfgs':
+    elif optimizer_str.lower() == "adagrad":
+        optimizer = torch.optim.Adagrad(W, lr=lr)
+
+    elif optimizer_str.lower() == "adam":
+        optimizer = torch.optim.Adam(W, lr=lr)
+
+    elif optimizer_str.lower() == "adamax":
+        optimizer = torch.optim.Adamax(W, lr=lr)
+
+    elif optimizer_str.lower() == "rmsprop":
+        optimizer = torch.optim.RMSprop(W, lr=lr)
+
+    elif optimizer_str.lower() == "sparseadam":
+        optimizer = torch.optim.SparseAdam(W, lr=lr)
+
+    elif optimizer_str.lower() == "sgd":
+        optimizer = torch.optim.SGD(W, lr=lr)
+
+    elif optimizer_str.lower() == "lbfgs":
         optimizer = torch.optim.LBFGS(W, lr=lr)
-    
-    elif optimizer_str.lower() == 'rprop':
+
+    elif optimizer_str.lower() == "rprop":
         optimizer = torch.optim.Rprop(W, lr=lr)
 
     else:
         error = "{} optimizer isn't implemented".format(optimizer_str)
         raise NotImplementedError(error)
-    
+
     # Initializing the Progress Bar
     loss_values = []
     if verbose:
-        widgets = [ '% Completion: ', progressbar.Percentage(), 
-                   progressbar.Bar('*'), ''] 
+        widgets = ["% Completion: ", progressbar.Percentage(), progressbar.Bar("*"), ""]
         bar = progressbar.ProgressBar(maxval=nb_epochs, widgets=widgets)
         bar.start()
 
     # Updating the weights at each training epoch
     temp_model = None
     for epoch in range(nb_epochs):
-
         # Backward pass and optimization
         def closure():
             optimizer.zero_grad()
@@ -183,7 +184,7 @@ def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000,
             loss.backward()
             return loss
 
-        if 'lbfgs' in optimizer_str.lower() :
+        if "lbfgs" in optimizer_str.lower():
             optimizer.step(closure)
         else:
             optimizer.step()
@@ -200,22 +201,22 @@ def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000,
             else:
                 print(error)
             break
-            
+
         # Otherwise, printing value of loss function
         else:
             temp_model = copy.deepcopy(model)
-            loss_values.append( loss_value )
+            loss_values.append(loss_value)
             if verbose:
-                widgets[-1] = "Loss: {:6.2f}".format( loss_value )
+                widgets[-1] = "Loss: {:6.2f}".format(loss_value)
 
         # Updating the progressbar
         if verbose:
-            bar.update( epoch + 1 )
-    
+            bar.update(epoch + 1)
+
     # Terminating the progressbar
     if verbose:
         bar.finish()
-        
+
     # Finilazing the model
     if temp_model is not None:
         temp_model = temp_model.eval()
@@ -224,5 +225,3 @@ def optimize(loss_function, model, optimizer_str, lr=1e-4, nb_epochs=1000,
         raise ValueError(error)
 
     return model, loss_values
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,29 @@
-matplotlib
-numpy
-pandas
-pip
-progressbar
-pyarrow
-scikit-learn 
-scipy
-sklearn
-torch
+contourpy==1.1.1 ; python_version >= '3.8'
+cycler==0.12.0 ; python_version >= '3.8'
+cython==3.0.2
+filelock==3.12.4 ; python_version >= '3.8'
+fonttools==4.43.0 ; python_version >= '3.8'
+jinja2==3.1.2 ; python_version >= '3.7'
+joblib==1.3.2 ; python_version >= '3.7'
+kiwisolver==1.4.5 ; python_version >= '3.7'
+markupsafe==2.1.3 ; python_version >= '3.7'
+matplotlib==3.8.0
+mpmath==1.3.0
+networkx==3.1 ; python_version >= '3.8'
+numpy==1.26.0
+packaging==23.2 ; python_version >= '3.7'
+pandas==2.1.1
+pillow==10.0.1 ; python_version >= '3.8'
+progressbar==2.5
+pyarrow==11.0.0
+pyparsing==3.1.1 ; python_full_version >= '3.6.8'
+python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+pytz==2023.3.post1
+scikit-learn==1.3.1
+scipy==1.11.3
+six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
+sympy==1.12 ; python_version >= '3.8'
+threadpoolctl==3.2.0 ; python_version >= '3.8'
+torch==2.0.1
+typing-extensions==4.8.0 ; python_version >= '3.8'
+tzdata==2023.3 ; python_version >= '2'

--- a/setup.py
+++ b/setup.py
@@ -1,157 +1,121 @@
 #! /usr/bin/env python
-#
-# Copyright 2019 Square Inc.
 
 # Apache License
 # Version 2.0, January 2004
 # http://www.apache.org/licenses/
 
-import os
 import codecs
+import os
 import re
-import glob
-from setuptools import setup, Extension, find_packages
-
-# Checking if numpy is installed
-try:
-  import numpy
-except:
-  import subprocess
-  print("numpy is not installed. So pysurvival will install it now.")
-  subprocess.call("pip install numpy", shell=True)
-  import numpy
+from distutils.core import Extension, setup
 
 # Package meta-data.
-NAME = 'pysurvival'
-DESCRIPTION = 'Open source package for Survival Analysis modeling'
-URL = 'https://www.pysurvival.io'
-EMAIL = 'stephane@squareup.com'
-AUTHOR = 'steph-likes-git'
+NAME = "pysurvival"
+DESCRIPTION = "Open source package for Survival Analysis modeling"
+URL = "https://www.pysurvival.io"
+EMAIL = "stephane@squareup.com"
+AUTHOR = "steph-likes-git"
 LICENSE = "Apache Software License (Apache 2.0)"
 
 # Current Directory
 try:
-    CURRENT_DIR = os.path.dirname(os.path.realpath(__file__)) + '/'
+    CURRENT_DIR = os.path.dirname(os.path.realpath(__file__)) + "/"
 except:
-    CURRENT_DIR = os.path.dirname(os.path.realpath('__file__')) + '/'
+    CURRENT_DIR = os.path.dirname(os.path.realpath("__file__")) + "/"
+
 
 # Utility functions
 def read_long_description():
-    with open(CURRENT_DIR + 'LONG_DESCRIPTION.txt', 'r') as f:
+    with open(CURRENT_DIR + "LONG_DESCRIPTION.txt", "r") as f:
         return f.read()
 
+
 def install_requires():
-	with open(CURRENT_DIR + 'requirements.txt', 'r') as requirements_file:
-	    requirements = requirements_file.readlines()
-	return requirements
+    with open(CURRENT_DIR + "requirements.txt", "r") as requirements_file:
+        requirements = requirements_file.readlines()
+    return requirements
+
 
 def read_version(*file_paths):
-    with codecs.open(os.path.join(CURRENT_DIR, *file_paths), 'r') as fp:
+    with codecs.open(os.path.join(CURRENT_DIR, *file_paths), "r") as fp:
         version_file = fp.read()
 
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+
 # Extensions Compilation arguments #
-extra_compile_args = ['-std=c++11', "-O3"] 
+extra_compile_args = ["-std=c++11", "-O3"]
 
 # Extensions info #
-ext_modules = [ 
-
-  Extension( 
-    name = "pysurvival.utils._functions",
-    sources = ["pysurvival/cpp_extensions/_functions.cpp",
-               "pysurvival/cpp_extensions/functions.cpp" ,
-               ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
-  ),
-
-  Extension( 
-    name = "pysurvival.utils._metrics",
-    sources = ["pysurvival/cpp_extensions/_metrics.cpp",
-               "pysurvival/cpp_extensions/non_parametric.cpp",
-               "pysurvival/cpp_extensions/metrics.cpp",
-               "pysurvival/cpp_extensions/functions.cpp",
-              ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
+ext_modules = [
+    Extension(
+        name="pysurvival.utils._functions",
+        sources=[
+            "pysurvival/cpp_extensions/_functions.cpp",
+            "pysurvival/cpp_extensions/functions.cpp",
+        ],
+        extra_compile_args=extra_compile_args,
+        language="c++",
     ),
+    Extension(
+        name="pysurvival.utils._metrics",
+        sources=[
+            "pysurvival/cpp_extensions/_metrics.cpp",
+            "pysurvival/cpp_extensions/non_parametric.cpp",
+            "pysurvival/cpp_extensions/metrics.cpp",
+            "pysurvival/cpp_extensions/functions.cpp",
+        ],
+        extra_compile_args=extra_compile_args,
+        language="c++",
+    ),
+    Extension(
+        name="pysurvival.models._survival_forest",
+        sources=[
+            "pysurvival/cpp_extensions/_survival_forest.cpp",
+            "pysurvival/cpp_extensions/survival_forest_data.cpp",
+            "pysurvival/cpp_extensions/survival_forest_utility.cpp",
+            "pysurvival/cpp_extensions/survival_forest_tree.cpp",
+            "pysurvival/cpp_extensions/survival_forest.cpp",
+        ],
+        extra_compile_args=extra_compile_args,
+        language="c++",
+    ),
+]
 
-  Extension( 
-    name = "pysurvival.models._non_parametric",
-    sources = ["pysurvival/cpp_extensions/_non_parametric.cpp",
-               "pysurvival/cpp_extensions/non_parametric.cpp",
-               "pysurvival/cpp_extensions/functions.cpp" 
-               ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
-  ),
-
-  Extension( 
-    name = "pysurvival.models._survival_forest",
-    sources = [ "pysurvival/cpp_extensions/_survival_forest.cpp",
-                "pysurvival/cpp_extensions/survival_forest_data.cpp",
-                "pysurvival/cpp_extensions/survival_forest_utility.cpp",
-                "pysurvival/cpp_extensions/survival_forest_tree.cpp",
-                "pysurvival/cpp_extensions/survival_forest.cpp", 
-                ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
-  ),
-
-  Extension( 
-    name = "pysurvival.models._coxph",
-    sources = [ "pysurvival/cpp_extensions/_coxph.cpp",
-                "pysurvival/cpp_extensions/functions.cpp" 
-              ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
-    include_dirs=[numpy.get_include()],
-  ),
-
-  Extension( 
-    name = "pysurvival.models._svm",
-    sources = [ "pysurvival/cpp_extensions/_svm.cpp", 
-              ],
-    extra_compile_args = extra_compile_args, 
-    language="c++", 
-    include_dirs=[numpy.get_include()],
-  ),
-  ]
-
-# Setup 
-setup(name=NAME,
-      version=read_version("pysurvival", "__init__.py"),
-      description=DESCRIPTION,
-      long_description=read_long_description(),
-      author=AUTHOR,
-      author_email=EMAIL,
-      url=URL,
-      license=LICENSE,
-      install_requires=install_requires(),
-      include_package_data=True,
-      package_data={ '': ['*.csv'], },
-      extras_require={ 'tests': ['pytest', 'pytest-pep8', ] },
-      classifiers=[
-          'Intended Audience :: Developers',
-          'Intended Audience :: Education',
-          'Intended Audience :: Science/Research',
-          'Operating System :: MacOS',
-          'Operating System :: Unix',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.7',
-          'Topic :: Scientific/Engineering',
-		      'Topic :: Scientific/Engineering :: Mathematics',
-          'Topic :: Scientific/Engineering :: Artificial Intelligence',
-          'Topic :: Software Development',
-          'Topic :: Software Development :: Libraries :: Python Modules'
-      ],
-      packages=find_packages(),
-      ext_modules=ext_modules,
-  )
+# Setup
+setup(
+    name=NAME,
+    version=read_version("pysurvival", "__init__.py"),
+    description=DESCRIPTION,
+    long_description=read_long_description(),
+    author=AUTHOR,
+    author_email=EMAIL,
+    url=URL,
+    license=LICENSE,
+    install_requires=install_requires(),
+    include_package_data=True,
+    package_data={
+        "": ["*.csv"],
+    },
+    extras_require={"dev": ["pytest", "black", "isort", "pylint"]},
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "Operating System :: MacOS",
+        "Operating System :: Unix",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    ext_modules=ext_modules,
+)


### PR DESCRIPTION
- Remove sklearn
- Lock requirements
- Replace setuptools with distutils.core
- Only keep pysurvival.models._survival_forest
- Use the new Py_SET_REFCNT() function instead of Py_REFCNT() (deprecated after Python 3.8)
- Use method the tp_repr instead of tp_print (removed from the API in Python 3.9)