### PR TITLE
 The 'sklearn' PyPI package is deprecated, use 'scikit-learn' in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ progressbar
 pyarrow
 scikit-learn 
 scipy
-sklearn
 torch


### PR DESCRIPTION
 The 'sklearn' PyPI package is deprecated, use 'scikit-learn' in requirements.txt